### PR TITLE
implemented subEvents filter

### DIFF
--- a/app/Http/Controllers/CalendarController.php
+++ b/app/Http/Controllers/CalendarController.php
@@ -385,7 +385,12 @@ class CalendarController extends Controller
                             ->whereIn('room_categories.id', $roomCategoryIds)))
                 )
             )
-            ->unless(empty($eventTypeIds), fn(EventBuilder $builder) => $builder->whereIn('event_type_id', array_map('intval', $eventTypeIds)))
+            ->unless(empty($eventTypeIds), function($builder) use ($eventTypeIds) {
+                return $builder->whereIn('event_type_id', array_map('intval', $eventTypeIds))
+                    ->orWhereHas('subEvents', function($subEventBuilder) use ($eventTypeIds) {
+                        $subEventBuilder->whereIn('event_type_id', array_map('intval', $eventTypeIds));
+                    });
+            })
             ->unless(is_null($hasAudience), fn(EventBuilder $builder) => $builder->where('audience', true))
             ->unless(is_null($hasNoAudience), fn(EventBuilder $builder) => $builder->where('audience', null)->orWhere('audience', false))
             ->unless(is_null($isLoud), fn(EventBuilder $builder) => $builder->where('is_loud', true))


### PR DESCRIPTION
e.g. when there is a main "blocker" event, which has a "meeting" subevent, and its filtered for meetings, the main blocker event is still shown

<img width="1036" alt="image" src="https://github.com/artwork-software/artwork/assets/44317110/5448cc6b-6d70-47b2-96f0-80abf27b05e0">