### PR TITLE
- fix fatal when events without projects are shown in calendar

### DIFF
--- a/app/Http/Resources/CalendarShowEventResource.php
+++ b/app/Http/Resources/CalendarShowEventResource.php
@@ -50,7 +50,7 @@ class CalendarShowEventResource extends JsonResource
             'days_of_shifts' => $this->days_of_shifts,
             'project' => $this->project,
             'option_string' => $this->option_string,
-            'projectLeaders' => $this->project->managerUsers,
+            'projectLeaders' => $this->project?->managerUsers,
             'is_series' => $this->is_series,
             'series' => $this->series
         ];

--- a/resources/js/Layouts/Components/SingleCalendarEvent.vue
+++ b/resources/js/Layouts/Components/SingleCalendarEvent.vue
@@ -154,7 +154,7 @@
                 {{ $t('Repeat event') }}
             </div>
             <!-- User-Icons -->
-            <div class="-ml-3 mb-0.5 w-full" v-if="$page.props.user.calendar_settings.project_management">
+            <div class="-ml-3 mb-0.5 w-full" v-if="$page.props.user.calendar_settings.project_management && event.projectLeaders?.length > 0">
                 <div v-if="event.projectLeaders && !project && zoomFactor >= 0.8"
                      class="mt-1 ml-5 flex flex-wrap">
                     <div class="flex flex-wrap flex-row -ml-1.5"


### PR DESCRIPTION
- fix SingleCalendarEvent.vue rendering if no projectLeaders are given