### PR TITLE
refs #ARTWORK-56-fix-timeline-validations | Fix timeline validations

### DIFF
--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -107,6 +107,7 @@ use Artwork\Modules\Shift\Services\ShiftUserService;
 use Artwork\Modules\ShiftQualification\Services\ShiftQualificationService;
 use Artwork\Modules\SubEvent\Services\SubEventService;
 use Artwork\Modules\Task\Services\TaskService;
+use Artwork\Modules\Timeline\Http\Requests\UpdateTimelinesRequest;
 use Artwork\Modules\Timeline\Models\Timeline;
 use Artwork\Modules\Timeline\Services\TimelineService;
 use Artwork\Modules\User\Http\Resources\UserWithoutShiftsResource;
@@ -2082,9 +2083,9 @@ class ProjectController extends Controller
         );
     }
 
-    public function updateTimeLines(Request $request): void
+    public function updateTimeLines(UpdateTimelinesRequest $request): void
     {
-        foreach ($request->timelines as $timeline) {
+        foreach ($request->collect('timelines') as $timeline) {
             $findTimeLine = Timeline::find($timeline['id']);
             $findTimeLine->update([
                 'start_date' => $timeline['start_date'],

--- a/artwork/Modules/Project/Services/ProjectService.php
+++ b/artwork/Modules/Project/Services/ProjectService.php
@@ -109,7 +109,10 @@ readonly class ProjectService
 
     public function save(Project $project): Project
     {
-        return $this->projectRepository->save($project);
+        /** @var Project $project */
+        $project = $this->projectRepository->save($project);
+
+        return $project;
     }
 
     public function softDelete(
@@ -478,7 +481,13 @@ readonly class ProjectService
                 ->orderBy('start_time', 'asc')
                 ->get() as $event
         ) {
-            $timeline = $event->timelines()->orderBy('start_date')->get()->toArray();
+            $timeline = $event->timelines()
+                ->orderBy('start_date')
+                ->orderBy('start')
+                ->orderBy('end_date')
+                ->orderBy('end')
+                ->get()
+                ->toArray();
 
             foreach ($timeline as &$singleTimeLine) {
                 $singleTimeLine['description_without_html'] = strip_tags($singleTimeLine['description']);

--- a/artwork/Modules/Project/Services/ProjectService.php
+++ b/artwork/Modules/Project/Services/ProjectService.php
@@ -478,25 +478,11 @@ readonly class ProjectService
                 ->orderBy('start_time', 'asc')
                 ->get() as $event
         ) {
-            $timeline = $event->timelines()->get()->toArray();
+            $timeline = $event->timelines()->orderBy('start_date')->get()->toArray();
 
             foreach ($timeline as &$singleTimeLine) {
                 $singleTimeLine['description_without_html'] = strip_tags($singleTimeLine['description']);
             }
-
-            usort($timeline, function ($a, $b) {
-                if ($a['start'] === null && $b['start'] === null) {
-                    return 0;
-                } elseif ($a['start'] === null) {
-                    return 1; // $a should come later in the array
-                } elseif ($b['start'] === null) {
-                    return -1; // $b should come later in the array
-                }
-
-                // Compare the 'start' values for ascending order
-                return strtotime($a['start']) - strtotime($b['start']);
-            });
-
 
             foreach ($event->shifts as $shift) {
                 $shift->load('shiftsQualifications');

--- a/artwork/Modules/Timeline/Http/Requests/UpdateTimelinesRequest.php
+++ b/artwork/Modules/Timeline/Http/Requests/UpdateTimelinesRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Artwork\Modules\Timeline\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateTimelinesRequest extends FormRequest
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'timelines' => 'required|array',
+            'timelines.*.start_date' => 'required|string',
+            'timelines.*.end_date' => 'required|string',
+            'timelines.*.start' => 'required|string',
+            'timelines.*.end' => 'required|string',
+            'timelines.*.description' => 'string|nullable',
+        ];
+    }
+}

--- a/database/factories/Artwork/Modules/Timeline/Models/TimelineFactory.php
+++ b/database/factories/Artwork/Modules/Timeline/Models/TimelineFactory.php
@@ -17,7 +17,9 @@ class TimelineFactory extends Factory
     {
         return [
             'event_id' => Event::factory(),
-            'start' => today(),
+            'start_date' => today(),
+            'end_date' => today(),
+            'start' => today()->addDay(),
             'end' => today()->addDay(),
             'description' => $this->faker->text(),
         ];

--- a/database/migrations/2024_06_25_183020_change_timeline_date_and_time_columns_not_nullable.php
+++ b/database/migrations/2024_06_25_183020_change_timeline_date_and_time_columns_not_nullable.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('timelines', static function (Blueprint $table) {
+            $table->date('start_date')->nullable(false)->change();
+            $table->date('end_date')->nullable(false)->change();
+            $table->time('start')->nullable(false)->change();
+            $table->time('end')->nullable(false)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('timelines', static function (Blueprint $table) {
+            $table->date('start_date')->nullable()->change();
+            $table->date('end_date')->nullable()->change();
+            $table->time('start')->nullable()->change();
+            $table->time('end')->nullable()->change();
+        });
+    }
+};

--- a/resources/css/Timeline/timeline.scss
+++ b/resources/css/Timeline/timeline.scss
@@ -1,0 +1,27 @@
+@layer components {
+    .timeline-container {
+        @apply flex flex-col gap-2 w-full;
+
+        .timeline-dates-container,
+        .timeline-times-container {
+            @apply flex flex-row gap-2;
+
+            .timeline-date-input,
+            .timeline-time-input {
+                @apply h-10 inputMain placeholder:xsLight placeholder:subpixel-antialiased focus:outline-none focus:ring-0 focus:border-secondary focus:border w-full border-gray-300;
+            }
+        }
+
+        .timeline-error-text {
+            @apply text-error text-xs;
+        }
+
+        .timeline-textarea {
+            @apply block w-full inputMain placeholder:xsLight placeholder:subpixel-antialiased focus:outline-none focus:ring-0 focus:border-secondary focus:border border-gray-300;
+        }
+    }
+
+    .delete-icon {
+        @apply hidden h-5 w-5 text-artwork-buttons-create hover:text-error cursor-pointer;
+    }
+}

--- a/resources/css/app.scss
+++ b/resources/css/app.scss
@@ -1,3 +1,5 @@
+@import "./Timeline/timeline";
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -20,7 +22,6 @@
     src: local('Lexend-Regular'), url('../fonts/Lexend-Regular.ttf') format('truetype');
 }
 
-/*https://svg-stripe-generator.web.app/*/
 @layer components {
     .stripes {
         background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBzdGFuZGFsb25lPSJubyI/PjwhRE9DVFlQRSBzdmcgUFVCTElDICItLy9XM0MvL0RURCBTVkcgMS4xLy9FTiIgImh0dHA6Ly93d3cudzMub3JnL0dyYXBoaWNzL1NWRy8xLjEvRFREL3N2ZzExLmR0ZCI+PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiPjxkZWZzPjxwYXR0ZXJuIGlkPSJwYXR0ZXJuX0tudFciIHBhdHRlcm5Vbml0cz0idXNlclNwYWNlT25Vc2UiIHdpZHRoPSIxNyIgaGVpZ2h0PSIxNyIgcGF0dGVyblRyYW5zZm9ybT0icm90YXRlKDQ1KSI+PGxpbmUgeDE9IjAiIHk9IjAiIHgyPSIwIiB5Mj0iMTciIHN0cm9rZT0iI0YzRjRGNiIgc3Ryb2tlLXdpZHRoPSI2Ii8+PC9wYXR0ZXJuPjwvZGVmcz4gPHJlY3Qgd2lkdGg9IjEwMCUiIGhlaWdodD0iMTAwJSIgZmlsbD0idXJsKCNwYXR0ZXJuX0tudFcpIiBvcGFjaXR5PSIxIi8+PC9zdmc+')

--- a/resources/js/Helper/ShiftPlanPlacementHandler.vue
+++ b/resources/js/Helper/ShiftPlanPlacementHandler.vue
@@ -85,23 +85,8 @@ export default class {
         document.body.removeChild(overlayDiv);
     }
 
-    getSortedTimelinesAndShifts() {
-        return this.timelinesAndShifts.sort(
-            (a, b) => {
-                let dateA = Object.keys(a).includes('shift_uuid') ?
-                        this.parseShiftDateFromDateAndTime(a.start_date, a.start) :
-                        this.parseTimelineDateFromDateAndTime(a.start_date, a.start),
-                    dateB = Object.keys(b).includes('shift_uuid') ?
-                        this.parseShiftDateFromDateAndTime(b.start_date, b.start) :
-                        this.parseTimelineDateFromDateAndTime(b.start_date, b.start);
-
-                return dateA - dateB;
-            }
-        );
-    }
-
     calculateHeights() {
-        this.getSortedTimelinesAndShifts().forEach((element) => {
+        this.timelinesAndShifts.forEach((element) => {
             let isShiftObject = this.isShiftObject(element),
                 domElement = this.getEventContainer().querySelector(
                     isShiftObject ?

--- a/resources/js/Pages/Projects/Components/AddTimeLineModal.vue
+++ b/resources/js/Pages/Projects/Components/AddTimeLineModal.vue
@@ -33,69 +33,61 @@
                                     <div class="my-4" v-for="(time, index) in timeLine">
                                         <SingleTimeLine :time="time" :index="index" :key="index"/>
                                     </div>
-                                    <div class="w-full flex group">
-                                        <div v-if="showAddTimeLineForm" class="grid grid-cols-1 sm:grid-cols-2 w-full gap-2">
-                                            <div>
-                                                <input type="text"
-                                                       onfocus="(this.type='date')"
-                                                       :placeholder="$t('Start*')"
+                                    <div class="flex flex-row group">
+                                        <div v-if="showAddTimeLineForm"
+                                             class="timeline-container">
+                                            <div class="timeline-dates-container">
+                                                <input class="timeline-date-input"
+                                                       type="date"
                                                        v-model="addTimeLineForm.start_date"
-                                                       class="h-10 inputMain placeholder:xsLight placeholder:subpixel-antialiased focus:outline-none focus:ring-0 focus:border-secondary focus:border-1 w-full border-gray-300"
-                                                       required
-                                                       @focusout="checkTime()"
-                                                />
-                                            </div>
-                                            <div>
-                                                <input type="text"
-                                                       onfocus="(this.type='date')"
-                                                       :placeholder="$t('End*')"
-                                                       v-model="addTimeLineForm.end_date"
-                                                       maxlength="3"
-                                                       required
-                                                       class="h-10 inputMain placeholder:xsLight placeholder:subpixel-antialiased focus:outline-none focus:ring-0 focus:border-secondary focus:border-1 w-full border-gray-300"
-                                                       @focusout="checkTime()"
-                                                />
-                                            </div>
-                                            <div>
-                                                <input type="text"
-                                                       onfocus="(this.type='time')"
                                                        :placeholder="$t('Start*')"
+                                                       @focusout="checkDates()"
+
+                                                />
+                                                <input class="timeline-date-input"
+                                                       type="date"
+                                                       v-model="addTimeLineForm.end_date"
+                                                       :placeholder="$t('Ende*')"
+                                                       @focusout="checkDates()"/>
+                                            </div>
+                                            <span class="timeline-error-text" v-if="showDatesNotGivenErrorText">
+                                                {{ $t('Please fill in both fields.') }}
+                                            </span>
+                                            <span class="timeline-error-text" v-if="showDatesStartGreaterThanEndText">
+                                                {{ $t('The start time must be before the end time.') }}
+                                            </span>
+                                            <div class="timeline-times-container">
+                                                <input class="timeline-time-input"
+                                                       type="time"
                                                        v-model="addTimeLineForm.start"
-                                                       class="h-10 inputMain placeholder:xsLight placeholder:subpixel-antialiased focus:outline-none focus:ring-0 focus:border-secondary focus:border-1 w-full border-gray-300"
-                                                       required
+                                                       :placeholder="$t('Start*')"
                                                        @focusout="checkTime()"
                                                 />
-                                            </div>
-                                            <div>
-                                                <input type="text"
-                                                       onfocus="(this.type='time')"
-                                                       :placeholder="$t('End*')"
+                                                <input class="timeline-time-input"
+                                                       type="time"
+                                                       :placeholder="$t('Ende*')"
                                                        v-model="addTimeLineForm.end"
-                                                       maxlength="3"
-                                                       required
-                                                       class="h-10 inputMain placeholder:xsLight placeholder:subpixel-antialiased focus:outline-none focus:ring-0 focus:border-secondary focus:border-1 w-full border-gray-300"
-                                                       @focusout="checkTime()"
-                                                />
+                                                       @focusout="checkTime()"/>
                                             </div>
-                                            <span class="mt-2 text-red-500 text-xs" v-show="helpText.length > 0">{{ helpText }}</span>
-                                            <div class="mt-2 col-span-2">
-                                                <textarea
-                                                    v-model="addTimeLineForm.description"
-                                                    rows="4"
-                                                    :placeholder="$t('Comment')"
-                                                    name="comment"
-                                                    id="comment"
-                                                    class="block w-full inputMain placeholder:xsLight placeholder:subpixel-antialiased focus:outline-none focus:ring-0 focus:border-secondary focus:border-1 border-gray-300"
-                                                />
-                                            </div>
+                                            <span class="timeline-error-text" v-if="showTimesNotGivenErrorText">
+                                                {{ $t('Please fill in both fields.') }}
+                                            </span>
+                                            <span class="timeline-error-text" v-if="showTimesStartGreaterThanEndText">
+                                                {{ $t('The start time must be before the end time.') }}
+                                            </span>
+                                            <textarea class="timeline-textarea"
+                                                      v-model="addTimeLineForm.description"
+                                                      rows="4"
+                                                      :placeholder="$t('Comment')"
+                                                      name="comment"
+                                                      id="comment"
+                                            />
                                         </div>
-                                        <div class="hidden group-hover:block ml-3">
-                                            <XCircleIcon @click="showAddTimeLineForm = false" class="mt-2 h-5 w-5 text-artwork-buttons-create hover:text-error cursor-pointer"/>
-                                        </div>
+                                        <XCircleIcon class="group-hover:block ml-2 mt-2 delete-icon" @click="showAddTimeLineForm = false"/>
                                     </div>
                                     <div class="h-1">
-                                        <div
-                                            class="mt-5 w-full h-1 border-b-2 border-dashed !flex items-center justify-center relative cursor-pointer group-hover:block" @click="showAddTimeLineForm = true">
+                                        <div class="mt-5 w-full h-1 border-b-2 border-dashed !flex items-center justify-center relative cursor-pointer group-hover:block"
+                                             @click="showAddTimeLineForm = true">
                                             <div class="absolute flex items-center justify-center w-full ">
                                                 <PlusCircleIcon class="h-6 w-6"/>
                                             </div>
@@ -113,119 +105,107 @@
         </Dialog>
     </TransitionRoot>
 </template>
-<script>
-import {defineComponent} from 'vue'
+
+<script setup>
+import {ref} from "vue";
 import {
     XCircleIcon,
     XIcon
 } from "@heroicons/vue/solid";
-import Permissions from "@/Mixins/Permissions.vue";
 import {
     Dialog,
     DialogPanel,
-    DialogTitle,
     TransitionChild,
     TransitionRoot
 } from "@headlessui/vue";
 import Input from "@/Jetstream/Input.vue";
 import {PlusCircleIcon} from "@heroicons/vue/outline";
 import SingleTimeLine from "@/Pages/Projects/Components/SingleTimeLine.vue";
-import {useForm} from "@inertiajs/vue3";
+import {router, useForm} from "@inertiajs/vue3";
 import FormButton from "@/Layouts/Components/General/Buttons/FormButton.vue";
 
-export default defineComponent({
-    name: "AddTimeLineModal",
-    mixins: [Permissions],
-    components: {
-        FormButton,
-        XCircleIcon,
-        SingleTimeLine,
-        Input,
-        Dialog,
-        DialogTitle,
-        TransitionChild,
-        TransitionRoot,
-        XIcon,
-        DialogPanel,
-        PlusCircleIcon
+const emits = defineEmits(['closed']),
+    props = defineProps({
+        event: Object,
+        timeLine: Object
+    }),
+    open = ref(true),
+    showAddTimeLineForm = ref((props.timeLine.length === 0)),
+    addTimeLineForm = useForm({
+        start_date: '',
+        end_date: '',
+        start: '',
+        end: '',
+        description: ''
+    }),
+    showDatesNotGivenErrorText = ref(false),
+    showDatesStartGreaterThanEndText = ref(false),
+    showTimesNotGivenErrorText = ref(false),
+    showTimesStartGreaterThanEndText = ref(false),
+    closeModal = (bool) => {
+        emits.call(this, 'closed', bool);
     },
-    props: [
-        'event',
-        'timeLine'
-    ],
-    data() {
-        return {
-            open: true,
-            helpText: '',
-            showAddTimeLineForm: this.timeLine.length === 0,
-            addTimeLineForm: useForm({
-                start_date: null,
-                end_date: null,
-                start: null,
-                end: null,
-                description: null
-            }),
-        }
-    },
-    emits: ['closed'],
-    methods: {
-        closeModal(bool) {
-            this.$emit('closed', bool);
-        },
-        saveTimeLines() {
-            let hasInvalid = false;
-            this.timeLine.forEach(function (timeline) {
-                if (timeline.start >= timeline.end) {
-                    hasInvalid = true;
-                }
-            });
-            if (!hasInvalid) {
-                if (this.showAddTimeLineForm) {
-                    if (this.checkTime()) {
-                        this.addTimeLineForm.post(
-                            route('add.timeline.row', {event: this.event.id}),
-                            {
-                                preserveState: true,
-                                preserveScroll: true,
-                                onFinish: () => {
-                                    //handle existing timelines which may be updated
-                                    this.updateTimes();
-                                }
+    saveTimeLines = () => {
+        let hasInvalid = false;
+        props.timeLine.forEach(function (timeline) {
+            if (
+                timeline.start_date.length === 0 ||
+                timeline.end_date.length === 0 ||
+                timeline.start.length === 0 ||
+                timeline.end.length === 0 ||
+                timeline.start_date > timeline.end_date ||
+                timeline.start > timeline.end)
+            {
+                hasInvalid = true;
+            }
+        });
+        if (!hasInvalid) {
+            if (showAddTimeLineForm.value) {
+                if (checkTime() && checkDates()) {
+                    addTimeLineForm.post(
+                        route('add.timeline.row', {event: props.event.id}),
+                        {
+                            preserveState: true,
+                            preserveScroll: true,
+                            onFinish: () => {
+                                //handle existing timelines which may be updated
+                                updateTimes();
                             }
-                        );
-                    }
-                    return;
+                        }
+                    );
                 }
-                //handle existing timelines which may be updated
-                this.updateTimes();
+                return;
             }
-        },
-        updateTimes() {
-            this.$inertia.patch(
-                route('update.timelines'),
-                {
-                    timelines: this.timeLine
-                }, {
-                    preserveState: true,
-                    preserveScroll: true,
-                    onFinish: () => {
-                        this.closeModal(true);
-                    }
-                }
-            )
-        },
-        checkTime() {
-            if (this.addTimeLineForm.start === null || this.addTimeLineForm.end === null) {
-                this.helpText = this.$t('Please fill in both fields.');
-                return false;
-            } else if (this.addTimeLineForm.start >= this.addTimeLineForm.end) {
-                this.helpText = this.$t('The start time must be before the end time.');
-                return false;
-            } else {
-                this.helpText = '';
-                return true;
-            }
+            //handle existing timelines which may be updated
+            updateTimes();
         }
-    }
-})
+    },
+    updateTimes = () => {
+
+    props.timeLine.forEach((timeline) => timeline.start_date = null);
+        router.patch(
+            route('update.timelines'),
+            {
+                timelines: props.timeLine
+            }, {
+                preserveState: true,
+                preserveScroll: true,
+                onFinish: () => {
+                    closeModal(true);
+                }
+            }
+        )
+    },
+    checkDates = () => {
+        showDatesNotGivenErrorText.value =  addTimeLineForm.start_date.length === 0 || addTimeLineForm.end_date.length === 0;
+        showDatesStartGreaterThanEndText.value = !showDatesNotGivenErrorText.value && addTimeLineForm.start_date > addTimeLineForm.end_date;
+
+        return !showDatesNotGivenErrorText.value && !showDatesStartGreaterThanEndText.value;
+    },
+    checkTime = () => {
+        showTimesNotGivenErrorText.value = addTimeLineForm.start.length === 0 || addTimeLineForm.end.length === 0;
+        showTimesStartGreaterThanEndText.value = !showTimesNotGivenErrorText.value && addTimeLineForm.start > addTimeLineForm.end;
+
+        return !showTimesNotGivenErrorText.value && !showTimesStartGreaterThanEndText.value;
+    };
 </script>

--- a/resources/js/Pages/Projects/Components/AddTimeLineModal.vue
+++ b/resources/js/Pages/Projects/Components/AddTimeLineModal.vue
@@ -14,7 +14,7 @@
                                      leave-to="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95">
                         <DialogPanel
                             class="relative transform overflow-hidden bg-white px-4 pt-5 pb-4 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-xl sm:p-6">
-                            <img src="/Svgs/Overlays/illu_appointment_edit.svg" class="-ml-6 -mt-8 mb-4"/>
+                            <img src="/Svgs/Overlays/illu_appointment_edit.svg" class="-ml-6 -mt-8 mb-4" alt="appointment"/>
                             <div class="absolute top-0 right-0 hidden pt-4 pr-4 sm:block">
                                 <button type="button" class="rounded-md bg-white text-gray-400 hover:text-gray-500"
                                         @click="closeModal">
@@ -165,7 +165,7 @@ const emits = defineEmits(['closed']),
                     addTimeLineForm.post(
                         route('add.timeline.row', {event: props.event.id}),
                         {
-                            preserveState: true,
+                            preserveState: false,
                             preserveScroll: true,
                             onFinish: () => {
                                 //handle existing timelines which may be updated
@@ -181,14 +181,12 @@ const emits = defineEmits(['closed']),
         }
     },
     updateTimes = () => {
-
-    props.timeLine.forEach((timeline) => timeline.start_date = null);
         router.patch(
             route('update.timelines'),
             {
                 timelines: props.timeLine
             }, {
-                preserveState: true,
+                preserveState: false,
                 preserveScroll: true,
                 onFinish: () => {
                     closeModal(true);

--- a/resources/js/Pages/Projects/Components/Timeline.vue
+++ b/resources/js/Pages/Projects/Components/Timeline.vue
@@ -31,7 +31,10 @@
         </div>
     </div>
 
-    <AddTimeLineModal v-if="showAddTimeLineModal" :event="event" :timeLine="timeLine" @closed="this.closeModal()"/>
+    <AddTimeLineModal v-if="showAddTimeLineModal"
+                      :event="event"
+                      :timeLine="timeLine"
+                      @closed="this.closeModal()"/>
 </template>
 <script>
 import {defineComponent} from 'vue'

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,5 +1,5 @@
 import './bootstrap';
-import '../css/app.css';
+import '../css/app.scss';
 import '../css/global.css';
 
 import { createApp, h } from 'vue';

--- a/tests/Feature/AppControllerTest.php
+++ b/tests/Feature/AppControllerTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use App\Http\Controllers\AppController;
 use App\Providers\RouteServiceProvider;
 use Artwork\Modules\GeneralSettings\Models\GeneralSettings;
+use Artwork\Modules\GeneralSettings\Services\GeneralSettingsService;
 use Artwork\Modules\Role\Enums\RoleEnum;
 use Artwork\Modules\User\Models\User;
 use Illuminate\Foundation\Testing\WithoutMiddleware;
@@ -17,11 +18,14 @@ class AppControllerTest extends TestCase
 
     private AppController $appController;
 
+    private GeneralSettings $generalSettings;
+
     protected function setUp(): void
     {
         parent::setUp();
 
         $this->appController = app(AppController::class);
+        $this->generalSettings = app(GeneralSettings::class);
     }
 
     public function testIndex(): void
@@ -33,6 +37,9 @@ class AppControllerTest extends TestCase
 
     public function testShowSetupPage(): void
     {
+        $this->generalSettings->setup_finished = false;
+        $this->generalSettings->save();
+
         $response = $this->get('/setup');
 
         $response->assertStatus(200);

--- a/tests/Feature/Event/EventControllerTest.php
+++ b/tests/Feature/Event/EventControllerTest.php
@@ -41,14 +41,12 @@ test('views events', function () {
     $calendarFilter->end_date = $today;
     $calendarFilter->save();
 
-    $response = $this->get(route('events'));
-
-//    $response->assertInertia(fn(AssertableInertia $page) => $page
-//        ->component('Events/EventManagement')
-//        ->has('events.events', 0));
+    $this->get(route('events'));
+    $now = now();
+    $currentEventCount = Event::startAndEndTimeOverlap($now, $today->endOfDay())->count();
 
     Event::factory()->create([
-        'start_time' => now(),
+        'start_time' => $now,
         'end_time' => $today->endOfDay(),
     ]);
 
@@ -56,7 +54,7 @@ test('views events', function () {
 
     $response->assertInertia(fn(AssertableInertia $page) => $page
         ->component('Events/EventManagement')
-        ->has('events.events', 1));
+        ->has('events.events', (1 + $currentEventCount)));
 });
 
 test('view shiftplan', function () {

--- a/tests/Unit/Artwork/Modules/Project/Services/ProjectServiceTest.php
+++ b/tests/Unit/Artwork/Modules/Project/Services/ProjectServiceTest.php
@@ -39,8 +39,12 @@ class ProjectServiceTest extends TestCase
 
     public function testGetProjects(): void
     {
-        $projects = Project::factory()->count(5)->create();
-        $this->assertEquals(5, $this->projectService->getProjects()->count());
+        $createCount = 5;
+        $currentProjectCount = $this->projectService->getProjects()->count();
+
+        Project::factory()->count($createCount)->create();
+
+        $this->assertEquals(($currentProjectCount + $createCount), $this->projectService->getProjects()->count());
     }
 
     public function testPin(): void
@@ -76,8 +80,12 @@ class ProjectServiceTest extends TestCase
 
     public function testGetAll(): void
     {
-        $projects = Project::factory()->count(5)->create();
-        $this->assertEquals(5, $this->projectService->getAll()->count());
+        $createCount = 5;
+        $currentProjectCount = $this->projectService->getProjects()->count();
+
+        Project::factory()->count($createCount)->create();
+
+        $this->assertEquals(($currentProjectCount + $createCount), $this->projectService->getAll()->count());
     }
 
     public function testGetByName(): void


### PR DESCRIPTION
- fix existing timeline validation
- improve ui
- translate mostly to composition api
- move timeline-container classes to app.scss
- fix broken sorting of timelines
- validate timelines properly on backend request
- change timelines table to not allow null values in start/end columns (time and date)