### PR TITLE
refs #ARTWORK-99-calendar-backend

### DIFF
--- a/artwork/Core/Database/Repository/BaseRepository.php
+++ b/artwork/Core/Database/Repository/BaseRepository.php
@@ -7,14 +7,14 @@ use Artwork\Core\Database\Models\Model;
 use Artwork\Core\Database\Models\Pivot;
 use BadMethodCallException;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Query\Builder as BaseBuilder;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Database\Query\Builder as BaseBuilder;
 use InvalidArgumentException;
 use Throwable;
 
 abstract class BaseRepository
 {
-    public function getNewModelInstance(): Model
+    public function getNewModelInstance(): Model|Pivot
     {
         throw new BadMethodCallException(
             'Implement in derived repository. Copy already derived functions and adapt.'

--- a/artwork/Modules/Event/Http/Resources/MinimalCacheBasedCalendarEventResource.php
+++ b/artwork/Modules/Event/Http/Resources/MinimalCacheBasedCalendarEventResource.php
@@ -1,0 +1,182 @@
+<?php
+
+namespace Artwork\Modules\Event\Http\Resources;
+
+use Artwork\Modules\Event\Models\Event;
+use Artwork\Modules\Project\Models\Project;
+use Artwork\Modules\Project\Models\ProjectStates;
+use Artwork\Modules\Shift\Models\Shift;
+use Artwork\Modules\SubEvent\Http\Resources\SubEventResource;
+use Artwork\Modules\User\Models\User;
+use Illuminate\Cache\CacheManager;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Throwable;
+
+/**
+ * @mixin Event
+ */
+class MinimalCacheBasedCalendarEventResource extends JsonResource
+{
+    /**
+     * @throws Throwable
+     * @return array<string, mixed>
+     */
+    //phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClass
+    public function toArray($request): array
+    {
+        /** @var array<int, Project> $cachedProjects */
+        /** @var array<int, ProjectStates> $cachedProjectStates */
+        /** @var array<int, Shift> $cachedShifts */
+        [
+            $cachedProjects,
+            $cachedProjectStates,
+            $cachedShifts
+        ] = $this->getCacheData();
+
+        /** @var string|null $projectName */
+        /** @var ProjectStates|null $projectState */
+        /** @var array<string, string> $projectLeaders */
+        [
+            $projectName,
+            $projectState,
+            $projectLeaders
+        ] = $this->aggregateProjectRelevantData(
+            $this->getAttribute('project_id'),
+            $cachedProjects,
+            $cachedProjectStates
+        );
+
+        return [
+            'id' => $this->getAttribute('id'),
+            'start' => $this->getAttribute('start_time')->utc()->toIso8601String(),
+            'startTime' => $this->getAttribute('start_time'),
+            'end' => $this->getAttribute('end_time')->utc()->toIso8601String(),
+            'allDay' => $this->getAttribute('allDay'),
+            'alwaysEventName' => $this->getAttribute('eventName'),
+            'eventName' => $this->getAttribute('eventName'),
+            'title' => $projectName ?:
+                $this->getAttribute('eventName') ?:
+                    $this->getAttribute('event_type')->getAttribute('name'),
+            'event_type_color' => $this->getAttribute('event_type')->getAttribute('hex_code'),
+            'eventTypeColorBackground' => $this->getAttribute('event_type')->getAttribute('hex_code') . '33',
+            'eventTypeName' => $this->getAttribute('event_type')->getAttribute('name'),
+            'eventTypeAbbreviation' => $this->getAttribute('event_type')->getAttribute('abbreviation'),
+            'audience' => $this->getAttribute('audience'),
+            'isLoud' => $this->getAttribute('is_loud'),
+            'projectName' => $projectName,
+            'projectStateColor' => $projectState?->getAttribute('color'),
+            'projectLeaders' => $projectLeaders,
+            'subEvents' => SubEventResource::collection($this->getAttribute('subEvents')),
+            'shifts' => $this->aggregateEventShifts($cachedShifts)
+        ];
+    }
+
+    /**
+     * @return array<int, array<int, mixed>>
+     * @throws Throwable
+     */
+    private function getCacheData(): array
+    {
+        /** @var CacheManager $cacheManager */
+        $cacheManager = app()->get(CacheManager::class);
+
+        return [
+            $cacheManager->get('projects'),
+            $cacheManager->get('projectStates'),
+            $cacheManager->get('shifts')
+        ];
+    }
+
+    /**
+     * @return array<int, array<int, mixed>>
+     * @throws Throwable
+     */
+    private function aggregateProjectRelevantData(
+        ?int $eventProjectId,
+        array $cachedProjects,
+        array $cachedProjectStates
+    ): array {
+        $project = $this->determineProject($eventProjectId, $cachedProjects);
+
+        return [
+            $project?->getAttribute('name'),
+            $this->determineProjectState($cachedProjectStates, $project),
+            $this->determineProjectLeaders($project?->getAttribute('managerUsers'))
+        ];
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function aggregateEventShifts(array $cachedShifts): array
+    {
+        $desiredShiftIds = $this->getAttribute('shifts')->pluck('id')->all();
+
+        return array_map(
+            function (Shift $shift): array {
+                return [
+                    'id' => $shift->getAttribute('id'),
+                    'craft' => [
+                        'id' => $shift->getAttribute('craft')->getAttribute('id'),
+                        'name' => $shift->getAttribute('craft')->getAttribute('name'),
+                        'abbreviation' => $shift->getAttribute('craft')->getAttribute('abbreviation')
+                    ],
+                    'worker_count' => $shift->getAttribute('users')->count() +
+                        $shift->getAttribute('freelancer')->count() +
+                        $shift->getAttribute('serviceProvider')->count(),
+                    'max_worker_count' => $shift->getAttribute('shiftsQualifications')->sum('value')
+                ];
+            },
+            array_filter(
+                $cachedShifts,
+                function (Shift $shift) use ($desiredShiftIds): bool {
+                    return in_array($shift->getAttribute('id'), $desiredShiftIds);
+                }
+            )
+        );
+    }
+
+    private function determineProject(int $eventProjectId, array $cachedProjects): Project|null
+    {
+        if ($eventProjectId) {
+            foreach ($cachedProjects as $cachedProject) {
+                if ($cachedProject->getAttribute('id') === $eventProjectId) {
+                    return $cachedProject;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private function determineProjectState(array $cachedProjectStates, ?Project $project): ?ProjectStates
+    {
+        foreach ($cachedProjectStates as $cachedProjectState) {
+            if ($cachedProjectState->getAttribute('id') === $project?->state) {
+                return $cachedProjectState;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function determineProjectLeaders(?Collection $managerUsers): array
+    {
+        return $managerUsers?->count() > 0 ?
+            array_map(
+                function (User $user): array {
+                    return [
+                        'profile_photo_url' => $user->getAttribute('profile_photo_url'),
+                        'first_name' => $user->getAttribute('first_name'),
+                        'last_name' => $user->getAttribute('last_name')
+                    ];
+                },
+                $managerUsers->all()
+            ) :
+            [];
+    }
+}

--- a/artwork/Modules/Project/Models/Project.php
+++ b/artwork/Modules/Project/Models/Project.php
@@ -40,7 +40,7 @@ use Laravel\Scout\Searchable;
  * @property string $updated_at
  * @property string $deleted_at
  * @property int $is_group
- * @property int $state
+ * @property ProjectStates $state
  * @property string $budget_deadline
  * @property Table|null $table
  * @property Collection<User> $managerUsers

--- a/artwork/Modules/Project/Models/ProjectStates.php
+++ b/artwork/Modules/Project/Models/ProjectStates.php
@@ -3,9 +3,9 @@
 namespace Artwork\Modules\Project\Models;
 
 use Artwork\Core\Database\Models\Model;
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Prunable;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 /**
@@ -27,8 +27,13 @@ class ProjectStates extends Model
         'color'
     ];
 
-    public function prunable(): Builder
+    public function project(): BelongsTo
     {
-        return static::where('deleted_at', '<=', now()->subMonth())->withTrashed();
+        return $this->belongsTo(
+            Project::class,
+            'state',
+            'id',
+            'projects'
+        );
     }
 }

--- a/artwork/Modules/Project/Models/ProjectUserPivot.php
+++ b/artwork/Modules/Project/Models/ProjectUserPivot.php
@@ -2,10 +2,12 @@
 
 namespace Artwork\Modules\Project\Models;
 
-use Illuminate\Database\Eloquent\Relations\Pivot;
+use Artwork\Core\Database\Models\Pivot;
 
 class ProjectUserPivot extends Pivot
 {
+    protected $table = 'project_user';
+
     protected $casts = [
         'access_budget' => 'boolean',
         'is_manager' => 'boolean',

--- a/artwork/Modules/Project/Repositories/ProjectRepository.php
+++ b/artwork/Modules/Project/Repositories/ProjectRepository.php
@@ -37,9 +37,9 @@ class ProjectRepository extends BaseRepository
             ->first();
     }
 
-    public function getAll(): Collection
+    public function getAll(array $with = []): Collection
     {
-        return Project::all();
+        return Project::query()->with($with)->get();
     }
 
     public function getByName(string $query): Collection

--- a/artwork/Modules/Project/Services/ProjectService.php
+++ b/artwork/Modules/Project/Services/ProjectService.php
@@ -8,11 +8,9 @@ use Artwork\Modules\Event\Models\Event;
 use Artwork\Modules\Event\Services\EventService;
 use Artwork\Modules\EventComment\Services\EventCommentService;
 use Artwork\Modules\Notification\Services\NotificationService;
-use Artwork\Modules\Project\Http\Requests\StoreProjectRequest;
 use Artwork\Modules\Project\Models\Project;
 use Artwork\Modules\Project\Repositories\ProjectRepository;
 use Artwork\Modules\ProjectTab\Services\ProjectTabService;
-use Artwork\Modules\Shift\Models\Shift;
 use Artwork\Modules\Shift\Services\ShiftFreelancerService;
 use Artwork\Modules\Shift\Services\ShiftService;
 use Artwork\Modules\Shift\Services\ShiftServiceProviderService;
@@ -22,13 +20,11 @@ use Artwork\Modules\SubEvent\Services\SubEventService;
 use Artwork\Modules\Task\Services\TaskService;
 use Artwork\Modules\Timeline\Services\TimelineService;
 use Artwork\Modules\User\Models\User;
-use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
-use Illuminate\Http\Request;
+use Illuminate\Support\Collection as IlluminateCollection;
 use Illuminate\Support\Facades\Auth;
 use Laravel\Scout\Builder;
-use Illuminate\Support\Collection as IlluminateCollection;
 
 readonly class ProjectService
 {
@@ -404,9 +400,9 @@ readonly class ProjectService
         return true;
     }
 
-    public function getAll(): Collection
+    public function getAll(array $with = []): Collection
     {
-        return $this->projectRepository->getAll();
+        return $this->projectRepository->getAll($with);
     }
 
     public function getByName(string $query): Collection

--- a/artwork/Modules/Shift/Repositories/ShiftRepository.php
+++ b/artwork/Modules/Shift/Repositories/ShiftRepository.php
@@ -12,6 +12,11 @@ use Illuminate\Database\Eloquent\Collection;
 
 class ShiftRepository extends BaseRepository
 {
+    public function getAll(array $with = []): Collection
+    {
+        return Shift::query()->with($with)->get();
+    }
+
     public function getById(int $shiftId): Shift|null
     {
         return Shift::find($shiftId);

--- a/artwork/Modules/Shift/Services/ShiftService.php
+++ b/artwork/Modules/Shift/Services/ShiftService.php
@@ -7,7 +7,6 @@ use Artwork\Modules\Change\Services\ChangeService;
 use Artwork\Modules\Craft\Models\Craft;
 use Artwork\Modules\Craft\Services\CraftService;
 use Artwork\Modules\Event\Models\Event;
-use Artwork\Modules\Event\Services\EventService;
 use Artwork\Modules\Notification\Enums\NotificationEnum;
 use Artwork\Modules\Notification\Services\NotificationService;
 use Artwork\Modules\PresetShift\Models\PresetShift;
@@ -23,10 +22,14 @@ readonly class ShiftService
 {
     public function __construct(
         private ShiftRepository $shiftRepository,
-        private EventService $eventService,
         private CraftService $craftService,
         private NotificationService $notificationService
     ) {
+    }
+
+    public function getAll(array $with = []): Collection
+    {
+        return $this->shiftRepository->getAll($with);
     }
 
     public function getById(int $shiftId): Shift|null

--- a/database/seeders/Benchmark2022ProjectSeeder.php
+++ b/database/seeders/Benchmark2022ProjectSeeder.php
@@ -17,7 +17,6 @@ class Benchmark2022ProjectSeeder extends Seeder
     {
         $project = Project::create([
             'name' => 'Benchmark 2022',
-            'description' => 'Per Day 10 Events, 5 Rooms, 2 Events per Room per Day',
             'shift_description' => 'Events of Doom',
             'key_visual_path' => 'M8AUVkujRBdqQu9rbS2Gart.JPG',
             'state' => 4,

--- a/resources/js/Layouts/Components/SingleCalendarEvent.vue
+++ b/resources/js/Layouts/Components/SingleCalendarEvent.vue
@@ -51,11 +51,11 @@
                         {{ event.eventTypeAbbreviation }}:
                     </div>
                     <div :style="{ width: width - (64 * zoomFactor) + 'px'}" class=" truncate">
-                        {{ event.eventName ?? event.project.name }}
+                        {{ event.eventName ?? event.projectName }}
                     </div>
                     <div v-if="$page.props.user.calendar_settings.project_status" class="absolute right-1">
-                        <div v-if="event.project?.state?.color"
-                             :class="[event.project.state.color,zoomFactor <= 0.8 ? 'border-2' : 'border-4']"
+                        <div v-if="event.projectStateColor"
+                             :class="[event.projectStateColor,zoomFactor <= 0.8 ? 'border-2' : 'border-4']"
                              class="rounded-full">
                         </div>
                     </div>
@@ -173,7 +173,7 @@
                                     </p>
                                 </div>
                             </MenuButton>
-                          <transition enter-active-class="transition-enter-active"
+                            <transition enter-active-class="transition-enter-active"
                                       enter-from-class="transition-enter-from"
                                       enter-to-class="transition-enter-to"
                                       leave-active-class="transition-leave-active"
@@ -190,7 +190,7 @@
                                                  alt=""/>
                                             <span class="ml-4">
                                                 {{ user.first_name }} {{ user.last_name }}
-                                                </span>
+                                            </span>
                                         </Link>
                                     </MenuItem>
                                 </MenuItems>
@@ -204,7 +204,7 @@
             <div v-for="shift in event.shifts">
                 <span>{{ shift.craft.abbreviation }}</span>
                 <span>
-                    &nbsp;({{ this.getCurrentShiftWorkerCount(shift) }}/{{ this.getMaxShiftWorkerCount(shift) }})
+                    &nbsp;({{ shift.worker_count }}/{{ shift.max_worker_count }})
                 </span>
             </div>
         </div>
@@ -433,18 +433,6 @@ export default {
         }
     },
     methods: {
-        getCurrentShiftWorkerCount(shift) {
-            return shift.users.length + shift.freelancer.length + shift.service_provider.length;
-        },
-        getMaxShiftWorkerCount(shift) {
-            let shiftWorkerCountByShiftsQualifications = 0;
-
-            shift.shifts_qualifications.forEach((shiftsQualification) => {
-                shiftWorkerCountByShiftsQualifications += shiftsQualification.value;
-            });
-
-            return shiftWorkerCountByShiftsQualifications;
-        },
         gcd(a, b) {
             return (b) ? this.gcd(b, a % b) : a;
         },

--- a/tests/Feature/Artwork/Modules/Calendar/Services/CalendarServiceTest.php
+++ b/tests/Feature/Artwork/Modules/Calendar/Services/CalendarServiceTest.php
@@ -3,6 +3,9 @@
 namespace Tests\Feature\Artwork\Modules\Calendar\Services;
 
 use Artwork\Modules\Calendar\Services\CalendarService;
+use Artwork\Modules\Project\Services\ProjectStateService;
+use Artwork\Modules\Shift\Services\ShiftService;
+use Illuminate\Cache\CacheManager;
 use Illuminate\Support\Collection;
 use Tests\TestCase;
 
@@ -17,7 +20,11 @@ class CalendarServiceTest extends TestCase
     {
         parent::setUp();
 
-        $this->calendarService = new CalendarService();
+        $this->calendarService = new CalendarService(
+            app()->get(CacheManager::class),
+            app()->get(ShiftService::class),
+            app()->get(ProjectStateService::class),
+        );
     }
 
     public function testCreateVacationAndAvailabilityPeriodCalendar(): void


### PR DESCRIPTION
- reduce overhead for project calendar (introduce MinimalCacheBasedCalendarEventResource)
- move worker count calculations to resource (so we reduce frontend overhead as we dont need to carry users, freelancers and service-providers all along)
- fix Benchmark2022ProjectSeeder
- use caching
- minimal frontend changes to match structure
- do not prune project states