### PR TITLE
#timo bulk event create

### DIFF
--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -14,6 +14,7 @@ use Artwork\Modules\Change\Services\ChangeService;
 use Artwork\Modules\Craft\Services\CraftService;
 use Artwork\Modules\DayService\Services\DayServicesService;
 use Artwork\Modules\Event\Events\OccupancyUpdated;
+use Artwork\Modules\Event\Http\Requests\EventBulkCreateRequest;
 use Artwork\Modules\Event\Http\Requests\EventStoreRequest;
 use Artwork\Modules\Event\Http\Requests\EventUpdateRequest;
 use Artwork\Modules\Event\Http\Resources\CalendarEventResource;
@@ -2360,9 +2361,203 @@ class EventController extends Controller
             $event->save();
         }
 
+
         return new JsonResponse([
             'desiredRoomIds' => array_values(array_unique($desiredRoomIds)),
             'desiredDays' => array_values(array_unique($desiredDaysOfEvents))
         ]);
+    }
+
+    //@todo: fix phpcs error - refactor function because complexity is rising
+    //phpcs:ignore Generic.Metrics.CyclomaticComplexity.MaxExceeded, Generic.Metrics.NestingLevel.TooHigh
+    public function updateMultiDuplicate(Request $request): JsonResponse
+    {
+        $desiredRoomIds = [];
+        $desiredDaysOfEvents = [];
+
+        $eventIds = $request->collect('events');
+        $duplicatedEvents = [];
+
+        foreach ($eventIds as $eventId) {
+            $originalEvent = $this->eventService->findEventById($eventId);
+
+            $duplicatedEvent = $originalEvent->replicate();
+            $duplicatedEvent->save();
+
+            $shifts = $originalEvent->shifts;
+            foreach ($shifts as $shift) {
+                $duplicatedShift = $shift->replicate();
+                $duplicatedShift->event_id = $duplicatedEvent->id;
+                $duplicatedShift->save();
+            }
+            $duplicatedEvents[] = $duplicatedEvent;
+        }
+
+        foreach ($duplicatedEvents as $event) {
+            $desiredRoomIds[] = $event->getAttribute('room_id');
+            $desiredDaysOfEvents[] = $event->getAttribute('start_time')->format('d.m.Y');
+            $desiredDaysOfEvents[] = $event->getAttribute('end_time')->format('d.m.Y');
+
+            if ($request->integer('newRoomId') !== null) {
+                $event->setAttribute('room_id', $request->integer('newRoomId'));
+                $desiredRoomIds[] = $event->getAttribute('room_id');
+            }
+            if ($request->string('date')->toString() === '') {
+                if ($request->integer('value') !== 0) {
+                    $endDate = Carbon::parse($event->getAttribute('end_time'));
+                    $startDate = Carbon::parse($event->getAttribute('start_time'));
+                    $shifts = $event->getAttribute('shifts');
+                    $calculationType = $request->integer('calculationType');
+                    $value = $request->integer('value');
+                    $type = $request->integer('type');
+
+                    // plus
+                    if ($calculationType === 1) {
+                        // stunden
+                        if ($type === 1) {
+                            $event->setAttribute('start_time', $startDate->addHours($value));
+                            $event->setAttribute('end_time', $endDate->addHours($value));
+                        }
+
+                        // Tage
+                        if ($type === 2) {
+                            $event->setAttribute('start_time', $startDate->addDays($value));
+                            $event->setAttribute('end_time', $endDate->addDays($value));
+                            foreach ($shifts as $shift) {
+                                $shiftStart = Carbon::parse($shift->getAttribute('start_date'));
+                                $shiftEnd = Carbon::parse($shift->getAttribute('end_date'));
+                                $shift->setAttribute('start_date', $shiftStart->addDays($value));
+                                $shift->setAttribute('end_date', $shiftEnd->addDays($value));
+                                $shift->save();
+                            }
+                        }
+                        // Wochen
+                        if ($type === 3) {
+                            $event->setAttribute('start_time', $startDate->addWeeks($value));
+                            $event->setAttribute('end_time', $endDate->addWeeks($value));
+                            foreach ($shifts as $shift) {
+                                $shiftStart = Carbon::parse($shift->getAttribute('start_date'));
+                                $shiftEnd = Carbon::parse($shift->getAttribute('end_date'));
+                                $shift->setAttribute('start_date', $shiftStart->addWeeks($value));
+                                $shift->setAttribute('end_date', $shiftEnd->addWeeks($value));
+                                $shift->save();
+                            }
+                        }
+                        // Monate
+                        if ($type === 4) {
+                            $event->setAttribute('start_time', $startDate->addMonths($value));
+                            $event->setAttribute('end_time', $endDate->addMonths($value));
+                            foreach ($shifts as $shift) {
+                                $shiftStart = Carbon::parse($shift->getAttribute('start_date'));
+                                $shiftEnd = Carbon::parse($shift->getAttribute('end_date'));
+                                $shift->setAttribute('start_date', $shiftStart->addMonths($value));
+                                $shift->setAttribute('end_date', $shiftEnd->addMonths($value));
+                                $shift->save();
+                            }
+                        }
+                        // Jahre
+                        if ($type === 5) {
+                            $event->setAttribute('start_time', $startDate->addYears($value));
+                            $event->setAttribute('end_time', $endDate->addYears($value));
+                            foreach ($shifts as $shift) {
+                                $shiftStart = Carbon::parse($shift->getAttribute('start_date'));
+                                $shiftEnd = Carbon::parse($shift->getAttribute('end_date'));
+                                $shift->setAttribute('start_date', $shiftStart->addYears($value));
+                                $shift->setAttribute('end_date', $shiftEnd->addYears($value));
+                                $shift->save();
+                            }
+                        }
+                    }
+
+                    // minus
+                    if ($calculationType === 2) {
+                        // stunden
+                        if ($type === 1) {
+                            $event->setAttribute('start_time', $startDate->subHours($value));
+                            $event->setAttribute('end_time', $endDate->subHours($value));
+                        }
+                        // Tage
+                        if ($type === 2) {
+                            $event->setAttribute('start_time', $startDate->subDays($value));
+                            $event->setAttribute('end_time', $endDate->subDays($value));
+                            foreach ($shifts as $shift) {
+                                $shiftStart = Carbon::parse($shift->getAttribute('start_date'));
+                                $shiftEnd = Carbon::parse($shift->getAttribute('end_date'));
+                                $shift->setAttribute('start_date', $shiftStart->subDays($value));
+                                $shift->setAttribute('end_date', $shiftEnd->subDays($value));
+                                $shift->save();
+                            }
+                        }
+                        // Wochen
+                        if ($type === 3) {
+                            $event->setAttribute('start_time', $startDate->subWeeks($value));
+                            $event->setAttribute('end_time', $endDate->subWeeks($value));
+                            foreach ($shifts as $shift) {
+                                $shiftStart = Carbon::parse($shift->getAttribute('start_date'));
+                                $shiftEnd = Carbon::parse($shift->getAttribute('end_date'));
+                                $shift->setAttribute('start_date', $shiftStart->subWeeks($value));
+                                $shift->setAttribute('end_date', $shiftEnd->subWeeks($value));
+                                $shift->save();
+                            }
+                        }
+                        // Monate
+                        if ($type === 4) {
+                            $event->setAttribute('start_time', $startDate->subMonths($value));
+                            $event->setAttribute('end_time', $endDate->subMonths($value));
+                            foreach ($shifts as $shift) {
+                                $shiftStart = Carbon::parse($shift->getAttribute('start_date'));
+                                $shiftEnd = Carbon::parse($shift->getAttribute('end_date'));
+                                $shift->setAttribute('start_date', $shiftStart->subMonths($value));
+                                $shift->setAttribute('end_date', $shiftEnd->subMonths($value));
+                                $shift->save();
+                            }
+                        }
+                        // Jahre
+                        if ($type === 5) {
+                            $event->setAttribute('start_time', $startDate->subYears($value));
+                            $event->setAttribute('end_time', $endDate->subYears($value));
+                            foreach ($shifts as $shift) {
+                                $shiftStart = Carbon::parse($shift->getAttribute('start_date'));
+                                $shiftEnd = Carbon::parse($shift->getAttribute('end_date'));
+                                $shift->setAttribute('start_date', $shiftStart->subYears($value));
+                                $shift->setAttribute('end_date', $shiftEnd->subYears($value));
+                                $shift->save();
+                            }
+                        }
+                    }
+                }
+                $desiredDaysOfEvents[] = $event->getAttribute('start_time')->format('d.m.Y');
+                $desiredDaysOfEvents[] = $event->getAttribute('end_time')->format('d.m.Y');
+            } else {
+                $endTime = Carbon::parse($event->getAttribute('end_time'))->format('H:i:s');
+                $startTime = Carbon::parse($event->getAttribute('start_time'))->format('H:i:s');
+
+                $newDate = Carbon::parse($request->string('date'));
+                $desiredDaysOfEvents[] = $newDate->format('d.m.Y');
+                $date = $newDate->format('Y-m-d');
+                $event->setAttribute('start_time', $date . ' ' . $startTime);
+                $event->setAttribute('end_time', $date . ' ' . $endTime);
+            }
+            $event->save();
+        }
+
+        return new JsonResponse([
+            'desiredRoomIds' => array_values(array_unique($desiredRoomIds)),
+            'desiredDays' => array_values(array_unique($desiredDaysOfEvents))
+        ]);
+    }
+
+
+    public function bulkProjectEventStore(
+        EventBulkCreateRequest $request,
+        Project $project
+    ): RedirectResponse {
+        $events = $request->input('events', []);
+
+        foreach ($events as $event) {
+            $this->eventService->createBulkEvent($event, $project);
+        }
+
+        return Redirect::back();
     }
 }

--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -3332,5 +3332,4 @@ class ProjectController extends Controller
 
         return $projects;
     }
-
 }

--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -157,6 +157,8 @@ class ProjectController extends Controller
         private readonly SectorService $sectorService,
         private readonly CostCenterService $costCenterService,
         private readonly AuthManager $authManager,
+        private readonly EventTypeService $eventTypeService,
+        private readonly RoomService $roomService,
     ) {
     }
 
@@ -194,6 +196,9 @@ class ProjectController extends Controller
             'genres' => $this->genreService->getAll(),
             'sectors' => $this->sectorService->getAll(),
             'createSettings' => app(ProjectCreateSettings::class),
+            'myLastProject' => $this->projectService->getMyLastProject($this->authManager->id()),
+            'eventTypes' => $this->eventTypeService->getAll(),
+            'rooms' => $this->roomService->getAllWithoutTrashed(),
         ]);
     }
 
@@ -277,6 +282,7 @@ class ProjectController extends Controller
 
         $project = Project::create([
             'name' => $request->name,
+            'user_id' => $this->authManager->id(),
             'number_of_participants' => $request->number_of_participants,
         ]);
 
@@ -1965,7 +1971,7 @@ class ProjectController extends Controller
         $headerObject->firstEventInProject = $project->events()->orderBy('start_time', 'ASC')->first();
         $headerObject->lastEventInProject = $project->events()->orderBy('end_time', 'DESC')->first();
         $headerObject->roomsWithAudience = Room::withAudience($project->id)->pluck('name', 'id');
-        $headerObject->eventTypes = EventTypeResource::collection(EventType::all())->resolve();
+        $headerObject->eventTypes = $this->eventTypeService->getAll();
         $headerObject->states = $this->projectStateService->getAll();
         $headerObject->projectGroups = $project->groups;
         $headerObject->groupProjects = Project::where('is_group', 1)->get();
@@ -1975,6 +1981,7 @@ class ProjectController extends Controller
         $headerObject->genres = $this->genreService->getAll();
         $headerObject->projectGenres = $project->genres;
         $headerObject->sectors = $this->sectorService->getAll();
+        $headerObject->rooms = $this->roomService->getAllWithoutTrashed();
         $headerObject->projectSectors = $project->sectors;
         $headerObject->projectState = $project->state;
         $headerObject->access_budget = $project->access_budget;
@@ -1987,6 +1994,7 @@ class ProjectController extends Controller
         $headerObject->projectCategoryIds = $project->categories()->pluck('category_id');
         $headerObject->projectGenreIds = $project->genres()->pluck('genre_id');
         $headerObject->projectSectorIds = $project->sectors()->pluck('sector_id');
+
 
         return inertia('Projects/Tab/TabContent', [
             'currentTab' => $projectTab,
@@ -3324,4 +3332,5 @@ class ProjectController extends Controller
 
         return $projects;
     }
+
 }

--- a/artwork/Modules/Checklist/Repositories/ChecklistRepository.php
+++ b/artwork/Modules/Checklist/Repositories/ChecklistRepository.php
@@ -96,6 +96,8 @@ class ChecklistRepository extends BaseRepository
     /**
      * Sortieren Sie die Checklisten nach dem Projektzeitraum.
      */
+    //@todo: fix phpcs error - refactor function because complexity is rising
+    //phpcs:ignore Generic.Metrics.CyclomaticComplexity.MaxExceeded, Generic.Metrics.NestingLevel.TooHigh
     private function sortChecklistsByProjectTime($checklists, $direction = 'asc')
     {
         return $checklists->sort(function ($a, $b) use ($direction) {
@@ -137,7 +139,9 @@ class ChecklistRepository extends BaseRepository
     {
         return $checklists->sortBy(function ($checklist) use ($direction) {
             $earliestDeadline = $checklist->tasks->whereNotNull('deadline')->min('deadline');
-            return $earliestDeadline ? strtotime($earliestDeadline) : ($direction === 'asc' ? PHP_INT_MAX : PHP_INT_MIN);
+            return $earliestDeadline ?
+                strtotime($earliestDeadline) :
+                ($direction === 'asc' ? PHP_INT_MAX : PHP_INT_MIN);
         })->values();
     }
 
@@ -162,6 +166,8 @@ class ChecklistRepository extends BaseRepository
     /**
      * Formatieren Sie die Checkliste mit sortierten Aufgaben und zugehörigen Projektdetails.
      */
+    //@todo: fix phpcs error - refactor function because complexity is rising
+    //phpcs:ignore Generic.Metrics.CyclomaticComplexity.MaxExceeded, Generic.Metrics.NestingLevel.TooHigh
     private function formatChecklist(Checklist $checklist, $sortedTasks, ProjectTabService $projectTabService)
     {
         return [
@@ -202,7 +208,8 @@ class ChecklistRepository extends BaseRepository
                     'done' => $task->done,
                     'done_by_user' => $task->user_who_done,
                     'done_at' => $task->done_at ? Carbon::parse($task->done_at)->format('d.m.Y, H:i') : null,
-                    'done_at_dt_local' => $task->done_at ? Carbon::parse($task->done_at)->toDateTimeLocalString() : null,
+                    'done_at_dt_local' => $task->done_at ? Carbon::parse($task->done_at)
+                        ->toDateTimeLocalString() : null,
                     'users' => $task->task_users,
                     'formatted_dates' => $task->getFormattedDates(),
                 ];

--- a/artwork/Modules/Event/Http/Requests/EventBulkCreateRequest.php
+++ b/artwork/Modules/Event/Http/Requests/EventBulkCreateRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Artwork\Modules\Event\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class EventBulkCreateRequest extends FormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'events' => 'required|array',
+            'events.*.name' => 'string',
+            'events.*.start_time' => 'nullable|date',
+            'events.*.end_time' => 'nullable|date',
+            'events.*.room' => 'array',
+            'events.*.room.id' => 'integer|exists:rooms,id',
+            'events.*.type' => 'array',
+            'events.*.type.id' => 'integer|exists:event_types,id',
+        ];
+    }
+}

--- a/artwork/Modules/Project/Models/Project.php
+++ b/artwork/Modules/Project/Models/Project.php
@@ -85,6 +85,7 @@ class Project extends Model
         'law_size',
         'cost_center_description',
         'is_group',
+        'user_id'
     ];
 
     protected $casts = [

--- a/artwork/Modules/Project/Repositories/ProjectRepository.php
+++ b/artwork/Modules/Project/Repositories/ProjectRepository.php
@@ -116,4 +116,9 @@ class ProjectRepository extends BaseRepository
     {
         return Project::where('is_group', '=', 1)->with('groups')->get();
     }
+
+    public function getMyLastProject(int $userId): ?Project
+    {
+        return Project::where('user_id', $userId)->orderBy('updated_at', 'DESC')->first();
+    }
 }

--- a/artwork/Modules/Project/Services/ProjectService.php
+++ b/artwork/Modules/Project/Services/ProjectService.php
@@ -634,4 +634,9 @@ readonly class ProjectService
         $this->projectRepository->update($project, $data);
         return $project;
     }
+
+    public function getMyLastProject(int $userId): ?Project
+    {
+        return $this->projectRepository->getMyLastProject($userId);
+    }
 }

--- a/artwork/Modules/ProjectTab/Enums/ProjectTabComponentEnum.php
+++ b/artwork/Modules/ProjectTab/Enums/ProjectTabComponentEnum.php
@@ -36,6 +36,8 @@ enum ProjectTabComponentEnum: string
 
     case BUDGET_INFORMATIONS = 'BudgetInformations';
 
+    case BULK_EDIT = 'BulkBody';
+
     /**
      * Get all available values
      * @return array<string, mixed>

--- a/artwork/Modules/ProjectTab/Services/ProjectTabService.php
+++ b/artwork/Modules/ProjectTab/Services/ProjectTabService.php
@@ -58,7 +58,7 @@ class ProjectTabService implements ServiceWithArrayCache
 
     public function findFirstProjectTabWithCalendarComponent(): ProjectTab|null
     {
-        return $this->findFirstProjectTabWithType(ProjectTabComponentEnum::CALENDAR);
+        return $this->findFirstProjectTabWithType(ProjectTabComponentEnum::BULK_EDIT);
     }
 
     private function findFirstProjectTabWithType(ProjectTabComponentEnum $type): ProjectTab|null

--- a/database/migrations/2024_08_06_160842_remove_project_id_form_checklist.php
+++ b/database/migrations/2024_08_06_160842_remove_project_id_form_checklist.php
@@ -22,7 +22,7 @@ return new class extends Migration
     public function down(): void
     {
         Schema::table('checklists', function (Blueprint $table) {
-            //
+            $table->foreignId('project_id')->nullable(false)->change();
         });
     }
 };

--- a/database/migrations/2024_08_12_162237_add_creator_to_project.php
+++ b/database/migrations/2024_08_12_162237_add_creator_to_project.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('projects', static function (Blueprint $table) {
+            $table->unsignedBigInteger('user_id')->nullable();
+            $table->foreign('user_id')
+                ->references('id')
+                ->on('users')
+                ->cascadeOnUpdate();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('projects', function (Blueprint $table) {
+            $table->dropForeign('user_id');
+            $table->dropColumn('user_id');
+        });
+    }
+};

--- a/database/migrations/2024_08_14_092617_add_bulk_edit_enum_to_components.php
+++ b/database/migrations/2024_08_14_092617_add_bulk_edit_enum_to_components.php
@@ -1,0 +1,94 @@
+<?php
+
+use Artwork\Modules\ProjectTab\Enums\ProjectTabComponentEnum;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        $enumValues = [
+            ProjectTabComponentEnum::TEXT_AREA->value,
+            ProjectTabComponentEnum::TEXT_FIELD->value,
+            ProjectTabComponentEnum::CHECKBOX->value,
+            ProjectTabComponentEnum::DROPDOWN->value,
+            ProjectTabComponentEnum::TITLE->value,
+            ProjectTabComponentEnum::CALENDAR->value,
+            ProjectTabComponentEnum::PROJECT_STATUS->value,
+            ProjectTabComponentEnum::CHECKLIST->value,
+            ProjectTabComponentEnum::PROJECT_TEAM->value,
+            ProjectTabComponentEnum::PROJECT_GROUP->value,
+            ProjectTabComponentEnum::PROJECT_ATTRIBUTES->value,
+            ProjectTabComponentEnum::SHIFT_TAB->value,
+            ProjectTabComponentEnum::RELEVANT_DATES_FOR_SHIFT_PLANNING->value,
+            ProjectTabComponentEnum::SHIFT_CONTACT_PERSONS->value,
+            ProjectTabComponentEnum::GENERAL_SHIFT_INFORMATION->value,
+            ProjectTabComponentEnum::BUDGET->value,
+            ProjectTabComponentEnum::PROJECT_BUDGET_DEADLINE->value,
+            ProjectTabComponentEnum::COMMENT_TAB->value,
+            ProjectTabComponentEnum::PROJECT_DOCUMENTS->value,
+            ProjectTabComponentEnum::PROJECT_TITLE->value,
+            ProjectTabComponentEnum::SEPARATOR->value,
+            ProjectTabComponentEnum::COMMENT_ALL_TAB->value,
+            ProjectTabComponentEnum::PROJECT_ALL_DOCUMENTS->value,
+            ProjectTabComponentEnum::CHECKLIST_ALL->value,
+            ProjectTabComponentEnum::BUDGET_INFORMATIONS->value,
+            // Weitere bestehende Werte
+            ProjectTabComponentEnum::BULK_EDIT->value, // Neuer Wert
+        ];
+
+        // Erstelle eine SQL-Anweisung, um die ENUM-Spalte zu ändern
+        $enumValuesString = "'" . implode("','", $enumValues) . "'";
+
+        // Führe die SQL-Anweisung aus, um die Spalte zu ändern
+        DB::statement("ALTER TABLE components MODIFY COLUMN type ENUM($enumValuesString)");
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        $enumValues = [
+            ProjectTabComponentEnum::TEXT_AREA->value,
+            ProjectTabComponentEnum::TEXT_FIELD->value,
+            ProjectTabComponentEnum::CHECKBOX->value,
+            ProjectTabComponentEnum::DROPDOWN->value,
+            ProjectTabComponentEnum::TITLE->value,
+            ProjectTabComponentEnum::CALENDAR->value,
+            ProjectTabComponentEnum::PROJECT_STATUS->value,
+            ProjectTabComponentEnum::CHECKLIST->value,
+            ProjectTabComponentEnum::PROJECT_TEAM->value,
+            ProjectTabComponentEnum::PROJECT_GROUP->value,
+            ProjectTabComponentEnum::PROJECT_ATTRIBUTES->value,
+            ProjectTabComponentEnum::SHIFT_TAB->value,
+            ProjectTabComponentEnum::RELEVANT_DATES_FOR_SHIFT_PLANNING->value,
+            ProjectTabComponentEnum::SHIFT_CONTACT_PERSONS->value,
+            ProjectTabComponentEnum::GENERAL_SHIFT_INFORMATION->value,
+            ProjectTabComponentEnum::BUDGET->value,
+            ProjectTabComponentEnum::PROJECT_BUDGET_DEADLINE->value,
+            ProjectTabComponentEnum::COMMENT_TAB->value,
+            ProjectTabComponentEnum::PROJECT_DOCUMENTS->value,
+            ProjectTabComponentEnum::PROJECT_TITLE->value,
+            ProjectTabComponentEnum::SEPARATOR->value,
+            ProjectTabComponentEnum::COMMENT_ALL_TAB->value,
+            ProjectTabComponentEnum::PROJECT_ALL_DOCUMENTS->value,
+            ProjectTabComponentEnum::CHECKLIST_ALL->value,
+            ProjectTabComponentEnum::BUDGET_INFORMATIONS->value,
+            // Weitere bestehende Werte
+            ProjectTabComponentEnum::BULK_EDIT->value,
+        ];
+
+        // Erstelle eine SQL-Anweisung, um die ENUM-Spalte zu ändern
+        $enumValuesString = "'" . implode("','", $enumValues) . "'";
+
+        // Führe die SQL-Anweisung aus, um die Spalte zu ändern
+        DB::statement("ALTER TABLE components MODIFY COLUMN type ENUM($enumValuesString)");
+    }
+};

--- a/database/seeders/DefaultComponentSeeder.php
+++ b/database/seeders/DefaultComponentSeeder.php
@@ -178,6 +178,14 @@ class DefaultComponentSeeder extends Seeder
                 'special' => true,
                 'sidebar_enabled' => true,
                 'permission_type' => ProjectTabComponentPermissionEnum::PERMISSION_TYPE_ALL_SEE_AND_EDIT->value
+            ],
+            [
+                'name' => 'Bulk Event Create',
+                'type' => ProjectTabComponentEnum::BULK_EDIT,
+                'data' => [],
+                'special' => true,
+                'sidebar_enabled' => false,
+                'permission_type' => ProjectTabComponentPermissionEnum::PERMISSION_TYPE_ALL_SEE_AND_EDIT->value
             ]
         ];
 
@@ -423,8 +431,12 @@ class DefaultComponentSeeder extends Seeder
             'order' => 2
         ]);
 
+
         $scheduleTab->components()->create([
-            'component_id' => Component::query()->where('name', 'Calendar')->first()->id,
+            'component_id' => Component::query()
+                ->where('type', ProjectTabComponentEnum::BULK_EDIT)
+                ->first()
+                ?->id,
             'order' => 1,
             'scope' => []
         ]);

--- a/lang/de.json
+++ b/lang/de.json
@@ -1933,5 +1933,18 @@
     "Project period descending": "Projektzeitraum absteigend",
     "ToDo-List name descending": "ToDo-Listen absteigend",
     "ToDo-List name ascending": "ToDo-Listen aufsteigend",
-    "My ToDo-Lists": "Meine ToDo-Listen"
+    "My ToDo-Lists": "Meine ToDo-Listen",
+    "Set up events": "Termine einrichten",
+    "Room": "Raum",
+    "Day": "Tag",
+    "The name is not given for {0} event(s)": "Der Name für {0} Termin(e) ist nicht angegeben",
+    "Event name is mandatory": "Terminname ist Pflicht",
+    "Bulk Event Create": "Massen-Terminerstellung Komponente",
+    "Remove Backdrop": "Hintergrund entfernen",
+    "Show Backdrop": "Hintergrund anzeigen",
+    "Close Window": "Fenster schließen",
+    "Duplicate events": "Termine duplizieren",
+    "Would you like to duplicate all selected appointments to another room or by a certain period of time?": "Möchtest du alle ausgewählten Termine in einen anderen Raum oder über einen bestimmten Zeitraum duplizieren?",
+    "Cancel selection": "Auswahl aufheben",
+    "Hold here to move": "Hier halten zum Verschieben"
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -1933,5 +1933,18 @@
     "Project period descending": "Project period descending",
     "ToDo-List name descending": "ToDo-List name descending",
     "ToDo-List name ascending": "ToDo-List name ascending",
-    "My ToDo-Lists": "My ToDo-Lists"
+    "My ToDo-Lists": "My ToDo-Lists",
+    "Set up events": "Set up events",
+    "Room": "Room",
+    "Day": "Day",
+    "The name is not given for {0} event(s)": "The name is not given for {0} event(s)",
+    "Event name is mandatory": "Event name is mandatory",
+    "Bulk Event Create": "Bulk Event Create Component",
+    "Remove Backdrop": "Remove Backdrop",
+    "Show Backdrop": "Show Backdrop",
+    "Close Window": "Close Window",
+    "Duplicate events": "Duplicate events",
+    "Would you like to duplicate all selected appointments to another room or by a certain period of time?": "Would you like to duplicate all selected appointments to another room or by a certain period of time?",
+    "Cancel selection": "Cancel selection",
+    "Hold here to move": "Hold here to move"
 }

--- a/resources/css/Base/BaseStyles.scss
+++ b/resources/css/Base/BaseStyles.scss
@@ -50,7 +50,7 @@
 
 
     .modal {
-        @apply relative transform bg-white text-left shadow-xl transition-all sm:my-8 sm:w-full rounded-lg;
+        @apply relative transform bg-white text-left shadow-2xl transition-all sm:my-8 sm:w-full rounded-lg;
     }
 
     .modal-header {

--- a/resources/js/Components/Calendar/Elements/SingleDayInCalendar.vue
+++ b/resources/js/Components/Calendar/Elements/SingleDayInCalendar.vue
@@ -1,5 +1,5 @@
 <template>
-    <div :style="{ height: zoom_factor * 115 + 'px', width: zoom_factor === 0.2 ? '50px' : zoom_factor * 90 + 'px', minWidth: zoom_factor === 0.2 ? '50px' : zoom_factor * 90 + 'px' }" :class="isFullscreen ? 'stickyDaysNoMarginLeft' : 'stickyDays'" class="text-secondary text-right bg-userBg">
+    <div :style="{ height: zoom_factor * 115 + 'px', width: zoom_factor === 0.2 ? '50px' : zoom_factor * 90 + 'px', minWidth: zoom_factor === 0.2 ? '50px' : zoom_factor * 90 + 'px' }" :class="isFullscreen ? 'stickyDaysNoMarginLeft' : 'stickyDays'" class="bg-userBg text-secondary text-right">
         <div :style="textStyle" class="mt-3 mr-2">
             <div>
                 {{ zoom_factor >= 0.8 ? day.day_string : '' }}

--- a/resources/js/Components/Globale/ComponentIcons.vue
+++ b/resources/js/Components/Globale/ComponentIcons.vue
@@ -36,6 +36,7 @@ export default {
     <IconInfoSquare class="w-6 h-6" v-if="type === 'GeneralShiftInformationComponent'" />
     <IconSeparator class="w-6 h-6" v-if="type === 'SeparatorComponent'" />
     <IconCurrencyEuro class="w-6 h-6" v-if="type === 'BudgetInformations'" />
+    <IconApps class="w-6 h-6" v-if="type === 'BulkBody'" />
 
     <!-- TextField, Checkbox, TextArea, Title, DropDown -->
 </template>

--- a/resources/js/Components/Modals/BaseModal.vue
+++ b/resources/js/Components/Modals/BaseModal.vue
@@ -3,24 +3,39 @@
         <Dialog as="div" class="relative z-50" @close="closeModal">
             <TransitionChild as="template" enter="ease-out duration-300" enter-from="opacity-0" enter-to="opacity-100"
                              leave="ease-in duration-200" leave-from="opacity-100" leave-to="opacity-0">
-                <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity"/>
+                <div class="fixed inset-0 bg-opacity-75 transition-opacity" :class="showBackdrop ? 'bg-gray-500' : ''"/>
+
             </TransitionChild>
             <div class="fixed inset-0 z-50 w-screen overflow-y-auto">
+
                 <div class="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
                     <TransitionChild as="template" enter="ease-out duration-300"
                                      enter-from="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
                                      enter-to="opacity-100 translate-y-0 sm:scale-100" leave="ease-in duration-200"
                                      leave-from="opacity-100 translate-y-0 sm:scale-100"
                                      leave-to="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95">
-                        <DialogPanel class="modal" :class="[modalSize, fullModal ? '' : 'sm:p-6 px-4 pt-5 pb-4']">
+                        <DialogPanel class="modal" :class="[modalSize, fullModal ? '' : 'sm:p-6 px-4 pt-5 pb-4']"  ref="containerRef">
+
                             <!--<img v-if="showImage" :src="modalImage" class=" mb-4 rounded-tl-lg"
                                  :class="fullModal ? '' : '-ml-6 -mt-6'"/>-->
                             <div class="absolute top-0 right-0 pt-4 pr-4 hidden sm:block z-50">
-                                <button type="button" class="rounded-md bg-white text-gray-400 hover:text-gray-500"
-                                        @click="closeModal(false)">
-                                    <span class="sr-only">Close</span>
-                                    <IconX stroke-width="1.5" class="h-6 w-6" aria-hidden="true"/>
-                                </button>
+                                <div class="flex items-center gap-x-3">
+                                    <div class="text-gray-400 hover:text-artwork-buttons-hover transition-all duration-150 ease-in-out cursor-pointer">
+                                        <div @click="showBackdrop = !showBackdrop">
+                                            <ToolTipDefault top show-background-icon :tooltip-text="showBackdrop ? $t('Remove Backdrop') : $t('Show Backdrop')"/>
+                                        </div>
+                                    </div>
+                                    <div ref="dragHandle" class=" hover:text-artwork-messages-waring transition-all duration-150 ease-in-out cursor-pointer" :class="isDragging ? 'text-artwork-messages-waring' : 'text-gray-400' ">
+                                        <div>
+                                            <ToolTipDefault top show-draggable :tooltip-text="$t('Hold here to move')"/>
+                                        </div>
+                                    </div>
+                                    <div class="text-gray-400 hover:text-artwork-messages-error transition-all duration-150 ease-in-out cursor-pointer">
+                                        <div @click="closeModal(false)">
+                                            <ToolTipDefault top show-x-icon :tooltip-text="$t('Close Window')"/>
+                                        </div>
+                                    </div>
+                                </div>
                             </div>
                             <div>
                                 <slot/>
@@ -33,28 +48,31 @@
         </Dialog>
     </TransitionRoot>
 </template>
-
 <script>
 import {Dialog, DialogPanel, DialogTitle, TransitionChild, TransitionRoot} from '@headlessui/vue'
 import {XIcon} from "@heroicons/vue/solid";
 import Permissions from "@/Mixins/Permissions.vue";
 import FormButton from "@/Layouts/Components/General/Buttons/FormButton.vue";
 import IconLib from "@/Mixins/IconLib.vue";
-
+import { IconBackground } from "@tabler/icons-vue";
+import ToolTipDefault from "@/Components/ToolTips/ToolTipDefault.vue";
 export default {
     name: "BaseModal",
     mixins: [Permissions, IconLib],
     components: {
+        ToolTipDefault,
         FormButton,
         Dialog,
         DialogTitle,
         TransitionChild,
         TransitionRoot,
-        XIcon, DialogPanel
+        XIcon, DialogPanel, IconBackground
     },
     data() {
         return {
             open: true,
+            showBackdrop: true,
+            isDragging: false
         }
     },
     props: {
@@ -73,13 +91,85 @@ export default {
         fullModal: {
             type: Boolean,
             default: false
-        }
+        },
+
+    },
+    mounted() {
+        this.$nextTick(() => {
+            const container = this.$refs.containerRef?.$el || this.$refs.containerRef;
+            if (container && container instanceof HTMLElement) {
+                this.makeContainerDraggable();
+            } else {
+                console.error('containerRef is not a valid DOM element');
+            }
+        });
     },
     emits: ['closed'],
     methods: {
         closeModal(bool) {
             this.$emit('closed', bool)
         },
+        makeContainerDraggable() {
+            const container = this.$refs.containerRef?.$el || this.$refs.containerRef;
+            const dragHandle = this.$refs.dragHandle;
+
+            if (!container || !(container instanceof HTMLElement) || !dragHandle) {
+                console.error('containerRef or dragHandle is not a valid DOM element');
+                return;
+            }
+
+            this.isDragging = false;
+            let offsetX, offsetY;
+
+            const onMouseDown = (event) => {
+                event.preventDefault();
+                this.isDragging = true;
+
+                // Berechne den Offset zwischen Mausposition und der aktuellen Position des Modals
+                const rect = container.getBoundingClientRect();
+                offsetX = event.clientX - rect.left;
+                offsetY = event.clientY - rect.top;
+
+                // Füge Event-Listener für Mousemove und Mouseup hinzu
+                document.addEventListener('mousemove', onMouseMove);
+                document.addEventListener('mouseup', onMouseUp);
+            };
+
+            const onMouseMove = (event) => {
+                if (!this.isDragging) return;
+
+                // Berechne die neue Position basierend auf der aktuellen Mausposition minus dem Offset
+                const newX = event.clientX - offsetX;
+                const newY = event.clientY - offsetY;
+
+                // Setze die neue Position des Modals sofort
+                container.style.position = 'absolute';
+                container.style.left = `${newX}px`;
+                container.style.top = `${newY}px`;
+            };
+
+            const onMouseUp = () => {
+                if (!this.isDragging) return;
+
+                this.isDragging = false;
+
+                // Entferne die Event-Listener
+                document.removeEventListener('mousemove', onMouseMove);
+                document.removeEventListener('mouseup', onMouseUp);
+            };
+
+            // Füge den mousedown Event-Listener nur am Drag-Handle hinzu
+            dragHandle.addEventListener('mousedown', onMouseDown);
+        },
     }
 }
 </script>
+
+<style scoped>
+.no-select {
+    user-select: none; /* Disable text selection */
+    -webkit-user-select: none; /* Safari */
+    -moz-user-select: none; /* Firefox */
+    -ms-user-select: none; /* Internet Explorer/Edge */
+}
+</style>

--- a/resources/js/Components/ToolTips/ToolTipDefault.vue
+++ b/resources/js/Components/ToolTips/ToolTipDefault.vue
@@ -1,8 +1,10 @@
 <script>
 import IconLib from "@/Mixins/IconLib.vue";
+import {IconBackground} from "@tabler/icons-vue";
 
 export default {
     name: "ToolTipDefault",
+    components: {IconBackground},
     mixins: [IconLib],
     data() {
         return {
@@ -21,6 +23,18 @@ export default {
         top: {
             type: Boolean,
             default: false
+        },
+        showBackgroundIcon: {
+            type: Boolean,
+            default: false
+        },
+        showDraggable: {
+            type: Boolean,
+            default: false
+        },
+        showXIcon: {
+            type: Boolean,
+            default: false
         }
     }
 }
@@ -31,10 +45,13 @@ export default {
         <!-- Button oder Icon, das den Tooltip triggert -->
         <button @mouseover="show = true" @mouseleave="show = false" class="focus:outline-none">
             <!-- Ihr SVG-Icon -->
-            <IconExclamationCircle class="h-5 w-5 text-artwork-buttons-context" />
+            <IconExclamationCircle class="h-5 w-5 text-artwork-buttons-context" v-if="!showBackgroundIcon && !showDraggable && !showXIcon" />
+            <IconBackground stroke-width="1.5" class="h-6 w-6" aria-hidden="true" v-if="showBackgroundIcon"/>
+            <IconDragDrop stroke-width="1.5" class="h-6 w-6" aria-hidden="true" v-if="showDraggable"  />
+            <IconX stroke-width="1.5" class="h-6 w-6" aria-hidden="true" v-if="showXIcon"  />
         </button>
         <!-- Tooltip-Text, der beim Hover erscheint -->
-        <div v-if="show && top" class="absolute z-10 -top-3 z-10 w-64 p-2 text-sm leading-tight text-white bg-black rounded-md shadow-lg transform -translate-x-1/2 -translate-y-full left-1/2">
+        <div v-if="show && top" class="absolute z-10 -top-3 text-center w-64 p-2 text-sm leading-tight text-white bg-black rounded-md shadow-lg transform -translate-x-1/2 -translate-y-full left-1/2">
             {{ tooltipText }}
             <!-- Tooltip Pfeil unten -->
             <div class="absolute bg-black h-3 w-3 transform rotate-45 left-1/2 -translate-x-1/2 -bottom-1.5"></div>

--- a/resources/js/Layouts/Components/EventComponent.vue
+++ b/resources/js/Layouts/Components/EventComponent.vue
@@ -98,9 +98,6 @@
                 </div>
             </div>
 
-
-
-
             <div v-if="!canEdit" class="flex w-full">
                 <div class="w-1/2 flex items-center my-auto" v-if="this.selectedProject?.id">
                     {{ $t('assigned to') }}: <a

--- a/resources/js/Layouts/Components/MultiDuplicateModal.vue
+++ b/resources/js/Layouts/Components/MultiDuplicateModal.vue
@@ -1,0 +1,252 @@
+<template>
+    <BaseModal @closed="closeModal" modal-image="/Svgs/Overlays/illu_appointment_edit.svg">
+        <div class="mx-4">
+            <!--   Heading   -->
+            <ModalHeader
+                :title="$t('Duplicate events')"
+                :description="$t('Would you like to duplicate all selected appointments to another room or by a certain period of time?')"
+            />
+            <div class="w-full">
+                <div class="mb-2">
+                    <Listbox as="div" class="sm:col-span-3" v-model="selectedRoom">
+                        <div class="relative">
+                            <ListboxButton class="menu-button">
+                                <span v-if="selectedRoom === null">{{ $t('No room displacement')}}</span>
+                                <div v-else> {{ selectedRoom?.name }}</div>
+                                <div class="mr-3">
+                                    <ChevronDownIcon class="h-5 w-5 text-gray-400" aria-hidden="true"/>
+                                </div>
+                            </ListboxButton>
+                            <ListboxOptions class="absolute w-full bg-artwork-navigation-background shadow-lg max-h-32 overflow-y-scroll rounded-md focus:outline-none z-10">
+                                <ListboxOption as="template" class="p-2 text-sm"
+                                               :value="null"
+                                               v-slot="{ active, selected }">
+                                    <li :class="[active ? 'bg-artwork-navigation-color/10 text-white' : 'text-secondary', 'rounded-md cursor-pointer flex justify-between']">
+                                        <div :class="[selected ? 'xsWhiteBold' : '', 'truncate']">
+                                            {{ $t('No room displacement')}}
+                                        </div>
+                                        <div v-if="selected">
+                                            <CheckIcon v-if="selected" class="h-5 w-5 text-success" aria-hidden="true"/>
+                                        </div>
+                                    </li>
+                                </ListboxOption>
+                                <ListboxOption as="template" class="p-2 text-sm"
+                                               v-for="room in rooms"
+                                               :key="room.id"
+                                               :value="room"
+                                               v-slot="{ active, selected }">
+                                    <li :class="[active ? 'bg-artwork-navigation-color/10 text-white' : 'text-secondary', 'rounded-md cursor-pointer flex justify-between']">
+                                        <div :class="[selected ? 'xsWhiteBold' : '', 'truncate']">
+                                            {{ room.name }}
+                                        </div>
+                                        <div v-if="selected">
+                                            <CheckIcon v-if="selected" class="h-5 w-5 text-success" aria-hidden="true"/>
+                                        </div>
+                                    </li>
+                                </ListboxOption>
+                            </ListboxOptions>
+                        </div>
+                    </Listbox>
+                </div>
+                <div class="grid grid-cols-1 sm:grid-cols-8 mb-2 gap-x-2">
+                    <div class="mb-2 col-span-1">
+                        <Listbox as="div" class="" v-model="selectedCalculationType">
+                            <div class="relative">
+                                <ListboxButton class="menu-button">
+                                    <div> {{ selectedCalculationType.type }}</div>
+                                    <div class="mr-3">
+                                        <ChevronDownIcon class="h-5 w-5 text-gray-400" aria-hidden="true"/>
+                                    </div>
+                                </ListboxButton>
+                                <ListboxOptions class="absolute w-full bg-artwork-navigation-background shadow-lg max-h-32 overflow-y-scroll rounded-md focus:outline-none  z-10">
+                                    <ListboxOption as="template" class="p-2 text-sm"
+                                                   v-for="calculation in calculationTypes"
+                                                   :key="calculation.id"
+                                                   :value="calculation"
+                                                   v-slot="{ active, selected }">
+                                        <li :class="[active ? 'bg-artwork-navigation-color/10 text-white' : 'text-secondary', 'rounded-md cursor-pointer flex justify-between']">
+                                            <div :class="[selected ? 'xsWhiteBold' : '', 'truncate']">
+                                                {{ calculation.type }}
+                                            </div>
+                                            <div v-if="selected">
+                                                <CheckIcon v-if="selected" class="h-5 w-5 text-success" aria-hidden="true"/>
+                                            </div>
+                                        </li>
+                                    </ListboxOption>
+                                </ListboxOptions>
+                            </div>
+                        </Listbox>
+                    </div>
+                    <div class="mb-2 col-span-3">
+                        <input type="number"
+                               v-model="editEvents.value"
+                               id="eventTitle"
+                               min="0" max="999"
+                               class="input h-12"/>
+                    </div>
+                    <div class="mb-2 col-span-4">
+                        <Listbox as="div" v-model="selectedTimeType">
+                            <div class="relative">
+                                <ListboxButton class="menu-button">
+                                    <div> {{ selectedTimeType.value }}</div>
+                                    <div class="mr-3">
+                                        <ChevronDownIcon class="h-5 w-5 text-gray-400" aria-hidden="true"/>
+                                    </div>
+                                </ListboxButton>
+                                <ListboxOptions class="absolute bg-artwork-navigation-background shadow-lg max-h-32 overflow-y-scroll rounded-md focus:outline-none z-10">
+                                    <ListboxOption as="template" class="p-2 text-sm"
+                                                   v-for="time in timeTypes"
+                                                   :key="time.id"
+                                                   :value="time"
+                                                   v-slot="{ active, selected }">
+                                        <li :class="[active ? 'bg-artwork-navigation-color/10 text-white' : 'text-secondary', 'rounded-md cursor-pointer flex justify-between']">
+                                            <div :class="[selected ? 'xsWhiteBold' : '', 'truncate']">
+                                                {{ time.value }}
+                                            </div>
+                                            <div v-if="selected">
+                                                <CheckIcon v-if="selected" class="h-5 w-5 text-success" aria-hidden="true"/>
+                                            </div>
+                                        </li>
+                                    </ListboxOption>
+                                </ListboxOptions>
+                            </div>
+                        </Listbox>
+                    </div>
+                </div>
+                <div class="pt-2 pb-4">
+                    <DateInputComponent
+                        v-model="editEvents.date"
+                        :label="editEvents.date === null ? $t('No postponement to date') : '' "
+                        id="eventTitle"
+                    />
+                </div>
+                <div class="w-full flex justify-center">
+                    <FormButton :text="$t('Save')"  @click="saveMultiDuplicate"/>
+                </div>
+            </div>
+        </div>
+    </BaseModal>
+</template>
+
+<script>
+import JetDialogModal from "@/Jetstream/DialogModal.vue";
+import {ChevronDownIcon, DotsVerticalIcon, PencilAltIcon, XCircleIcon, XIcon} from '@heroicons/vue/outline';
+import {
+    Listbox,
+    ListboxButton,
+    ListboxOption,
+    ListboxOptions,
+    Menu,
+    MenuButton,
+    MenuItem,
+    MenuItems
+} from "@headlessui/vue";
+import {CheckIcon, ChevronUpIcon, TrashIcon} from "@heroicons/vue/solid";
+import SvgCollection from "@/Layouts/Components/SvgCollection.vue";
+import Input from "@/Jetstream/Input.vue";
+import ConfirmationComponent from "@/Layouts/Components/ConfirmationComponent.vue";
+import TagComponent from "@/Layouts/Components/TagComponent.vue";
+import InputComponent from "@/Layouts/Components/InputComponent.vue";
+import {useForm} from "@inertiajs/vue3";
+import Permissions from "@/Mixins/Permissions.vue";
+import FormButton from "@/Layouts/Components/General/Buttons/FormButton.vue";
+import BaseModal from "@/Components/Modals/BaseModal.vue";
+import DateInputComponent from "@/Components/Inputs/DateInputComponent.vue";
+import ModalHeader from "@/Components/Modals/ModalHeader.vue";
+
+export default {
+    name: 'MultiDuplicateModal',
+    mixins: [Permissions],
+    components: {
+        ModalHeader,
+        DateInputComponent,
+        BaseModal,
+        FormButton,
+        Input,
+        JetDialogModal,
+        XIcon,
+        XCircleIcon,
+        Listbox,
+        ListboxButton,
+        ListboxOption,
+        ListboxOptions,
+        ChevronDownIcon,
+        ChevronUpIcon,
+        SvgCollection,
+        CheckIcon,
+        Menu,
+        MenuButton,
+        MenuItem,
+        MenuItems,
+        PencilAltIcon,
+        TrashIcon,
+        DotsVerticalIcon,
+        ConfirmationComponent,
+        TagComponent,
+        InputComponent
+    },
+    data() {
+        return {
+            calculationTypes: [
+                {id: 1, type: '+'},
+                {id: 2, type: '-'},
+            ],
+            timeTypes: [
+                {id: 1, value: this.$t('Hour(s)')},
+                {id: 2, value: this.$t('Day(s)')},
+                {id: 3, value: this.$t('Week(s)')},
+                {id: 4, value: this.$t('Month(s)')},
+                {id: 5, value: this.$t('Year(s)')},
+            ],
+            editEvents: useForm({
+                events: this.checkedEvents,
+                newRoomId: null,
+                calculationType: null,
+                value: 0,
+                type:  null,
+                date: null
+            }),
+            selectedCalculationType: {id: 1, type: '+'},
+            selectedTimeType: {id: 1, value: this.$t('Hour(s)')},
+            selectedRoom: null,
+        }
+    },
+    props: ['checkedEvents', 'rooms'],
+    emits: ['closed'],
+    methods: {
+        closeModal(bool, desiredRoomIds = null, desiredDays = null) {
+            this.$emit('closed', bool, desiredRoomIds, desiredDays);
+        },
+        saveMultiDuplicate() {
+            this.editEvents.type = this.selectedTimeType.id;
+            this.editEvents.calculationType = this.selectedCalculationType.id;
+            this.editEvents.newRoomId = this.selectedRoom?.id;
+
+            let desiredRoomIds = null,
+                desiredDays;
+
+            axios.patch(
+                route('multi-duplicate.save'),
+                {
+                    events: this.editEvents.events,
+                    newRoomId: this.editEvents.newRoomId,
+                    calculationType: this.editEvents.calculationType,
+                    value: this.editEvents.value,
+                    type: this.editEvents.type,
+                    date: this.editEvents.date
+                }
+            ).then((response) => {
+                desiredRoomIds = response.data.desiredRoomIds;
+                desiredDays = response.data.desiredDays;
+            }).finally(() => {
+                this.editEvents.newRoomId = null;
+                this.editEvents.calculationType = null;
+                this.editEvents.value = 0;
+                this.editEvents.type = null;
+                this.editEvents.date = null;
+                this.closeModal(true, desiredRoomIds, desiredDays);
+            });
+        }
+    },
+}
+</script>

--- a/resources/js/Layouts/Components/ProjectCreateModal.vue
+++ b/resources/js/Layouts/Components/ProjectCreateModal.vue
@@ -1,28 +1,29 @@
 <template>
     <BaseModal @closed="this.$emit('closeCreateProjectModal')" full-modal>
             <div class="">
-                <ModalHeader
-                    :title="project ? $t('Edit basic data') : isCreateProjectTab ? $t('New project') : $t('New project group')"
-                    :description="$t('Please fill in the following fields to create a new project.')"
-                    full-modal
-                />
 
-                <div class="px-6" v-if="!project">
-                    <div class="hidden sm:block">
-                        <div class="border-gray-200">
-                            <nav class="-mb-px uppercase text-xs tracking-wide pt-4 flex space-x-8"
-                                 aria-label="Tabs">
-                                <a @click="changeTab(tab)" v-for="tab in tabs" href="#" :key="tab.name"
-                                   :class="[tab.current ? 'border-artwork-buttons-create text-artwork-buttons-create' : 'border-transparent text-secondary hover:text-gray-600 hover:border-gray-300', 'whitespace-nowrap py-4 px-1 border-b-2 font-medium font-semibold']"
-                                   :aria-current="tab.current ? 'page' : undefined">
-                                    {{ tab.name }}
-                                </a>
-                            </nav>
-                        </div>
-                    </div>
+                <div class="px-6 mt-5 modal-header"  v-if="!project">
+                    <SwitchGroup as="div" class="flex items-center">
+                        <SwitchLabel as="span" class="mr-3 model-title cursor-pointer" :class="createProject ? '' : '!text-gray-300'">
+                            {{ $t('Project') }}
+                        </SwitchLabel>
+                        <Switch v-model="createProject" :class="[!createProject ? 'bg-artwork-buttons-create' : 'bg-artwork-buttons-create', 'relative inline-flex h-5 w-12 flex-shrink-0 rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none']">
+                            <span aria-hidden="true" :class="[!createProject  ? 'translate-x-7' : 'translate-x-0', 'pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out']" />
+                        </Switch>
+                        <SwitchLabel as="span" class="ml-3 model-title cursor-pointer" :class="!createProject ? '' : '!text-gray-300'">
+                            {{ $t('Project group') }}
+                        </SwitchLabel>
+                    </SwitchGroup>
                 </div>
-                <div v-if="isCreateProjectTab">
-                    <form @submit.prevent="addProject">
+                <div v-else>
+                    <ModalHeader
+                        :title="project ? $t('Edit basic data') : isCreateProjectTab ? $t('New project') : $t('New project group')"
+                        :description="$t('Please fill in the following fields to create a new project.')"
+                        full-modal
+                    />
+                </div>
+                <div v-if="createProject">
+                    <div>
                        <div v-if="project" class="px-6 py-2">
                            <KeyVisual :project="project"  />
                        </div>
@@ -242,17 +243,29 @@
                             </div>
 
                         </div>
-                        <div class="w-full items-center text-center pb-6">
-                            <FormButton
-                                type="submit"
-                                :text="project ? $t('Save') : $t('Create')"
+                        <div class="w-full flex items-center justify-end gap-x-4 pb-6 px-6">
+                            <BaseButton
+                                v-if="!project"
+                                @click="addProject(true)"
+                                :text="$t('Set up events')"
                                 class="mt-8 inline-flex items-center"
-                            />
+                                classes="!w-fit gap-x-2 h-12 bg-artwork-buttons-create">
+                                <IconCalendarMonth class="w-5 h-5" />
+                            </BaseButton>
+                            <BaseButton
+                                type="submit"
+                                @click="addProject(false)"
+                                :text="project ? $t('Save') : $t('Create')"
+                                class="mt-8 inline-flex items-center "
+                                classes="!w-fit gap-x-2 h-12"
+                            >
+                                <IconCirclePlus class="w-5 h-5" />
+                            </BaseButton>
                         </div>
-                    </form>
+                    </div>
                 </div>
-                <div v-if="isCreateProjectGroupTab && !project">
-                    <form @submit.prevent="addProject" class="px-6 pb-6">
+                <div v-if="!createProject && !project">
+                    <div class="px-6 pb-6">
                         <div class="py-4 w-full">
                             <TextInputComponent
                                 id="sourceName"
@@ -435,12 +448,26 @@
                                 </span>
                             </div>
                         </div>
-                        <div class="w-full items-center text-center mt-5 justify-center flex">
-                            <FormButton
+                        <div class="w-full flex items-center justify-end gap-x-4 pb-6 px-6">
+                            <BaseButton
+                                v-if="!project"
+                                @click="addProject(true)"
+                                :text="$t('Set up events')"
+                                class="mt-8 inline-flex items-center"
+                                classes="!w-fit gap-x-2 h-12 bg-artwork-buttons-create">
+                                <IconCalendarMonth class="w-5 h-5" />
+                            </BaseButton>
+                            <BaseButton
                                 type="submit"
-                                :disabled="this.createProjectForm.name === ''" :text="$t('Create')"/>
+                                @click="addProject(false)"
+                                :text="project ? $t('Save') : $t('Create')"
+                                class="mt-8 inline-flex items-center "
+                                classes="!w-fit gap-x-2 h-12"
+                            >
+                                <IconCirclePlus class="w-5 h-5" />
+                            </BaseButton>
                         </div>
-                    </form>
+                    </div>
                 </div>
             </div>
     </BaseModal>
@@ -464,7 +491,7 @@ import {
     ListboxOptions,
     Menu,
     MenuButton,
-    MenuItems
+    MenuItems, Switch, SwitchGroup, SwitchLabel
 } from "@headlessui/vue";
 import FormButton from "@/Layouts/Components/General/Buttons/FormButton.vue";
 import BaseModal from "@/Components/Modals/BaseModal.vue";
@@ -480,11 +507,16 @@ import DateInputComponent from "@/Components/Inputs/DateInputComponent.vue";
 import ModalHeader from "@/Components/Modals/ModalHeader.vue";
 import BaseTabs from "@/Components/Tabs/BaseTabs.vue";
 import ProjectSearch from "@/Components/SearchBars/ProjectSearch.vue";
+import BaseButton from "@/Layouts/Components/General/Buttons/BaseButton.vue";
 
 export default {
     name: 'ProjectCreateModal',
     mixins: [IconLib, ColorHelper],
     components: {
+        BaseButton,
+        Switch,
+        SwitchLabel,
+        SwitchGroup,
         ProjectSearch,
         BaseTabs,
         ModalHeader,
@@ -553,6 +585,7 @@ export default {
                 keyVisual: null,
             }),
             uploadKeyVisualFeedback: "",
+            createProject: true
         }
     },
     computed: {
@@ -589,7 +622,7 @@ export default {
                 this.createProjectForm.isGroup = true;
             }
         },
-        addProject() {
+        addProject(bool) {
             this.projectGroupProjects.forEach((projectToAdd) => {
                 this.createProjectForm.projects.push(projectToAdd.id);
             });
@@ -605,7 +638,7 @@ export default {
                 this.createProjectForm.patch(
                     route('projects.update', this.project.id), {
                         onSuccess: () => {
-                            this.$emit('closeCreateProjectModal', true);
+                            this.$emit('closeCreateProjectModal', bool);
                         }
                     }
                 );
@@ -613,7 +646,7 @@ export default {
                 this.createProjectForm.post(
                     route('projects.store'), {
                         onSuccess: () => {
-                            this.$emit('closeCreateProjectModal', true);
+                            this.$emit('closeCreateProjectModal', bool);
                         }
                     }
                 );

--- a/resources/js/Mixins/IconLib.vue
+++ b/resources/js/Mixins/IconLib.vue
@@ -111,7 +111,8 @@ import {
     IconSeparator,
     IconDeviceFloppy,
     IconNote,
-    IconCalendarStar
+    IconCalendarStar,
+    IconApps
 
 } from "@tabler/icons-vue";
 export default {
@@ -227,7 +228,8 @@ export default {
         IconInfoSquare,
         IconSeparator,
         IconDeviceFloppy,
-        IconNote
+        IconNote,
+        IconApps
     }
 }
 </script>

--- a/resources/js/Pages/Projects/Components/AddBulkEventsModal.vue
+++ b/resources/js/Pages/Projects/Components/AddBulkEventsModal.vue
@@ -1,0 +1,60 @@
+<template>
+    <BaseModal v-if="true" @closed="$emit('closed')" modal-size="max-w-6xl">
+        <div class="modal-header">
+            <div class="flex items-center gap-x-4">
+                <div class="model-title">
+                    {{ $t('Events') }}
+                </div>
+                <div class="model-title !text-gray-400 text-md">
+                    ({{ project.name}})
+                </div>
+            </div>
+        </div>
+
+        <div>
+            <BulkBody
+                :rooms="rooms"
+                :event-types="event_types"
+                :project="project"
+                @closed="$emit('closed')"
+                is-in-modal
+            />
+        </div>
+    </BaseModal>
+</template>
+
+<script setup>
+
+import BaseModal from "@/Components/Modals/BaseModal.vue";
+import {reactive, ref, watch} from "vue";
+import {IconCheck, IconTrash, IconChevronDown, IconCirclePlus, IconCopy, IconPlus, IconCircleCheckFilled, IconX} from "@tabler/icons-vue";
+import {Listbox, ListboxButton, ListboxOption, ListboxOptions, Switch, SwitchGroup, SwitchLabel} from "@headlessui/vue";
+import Input from "@/Layouts/Components/InputComponent.vue";
+import BaseButton from "@/Layouts/Components/General/Buttons/BaseButton.vue";
+import BulkHeader from "@/Pages/Projects/Components/BulkComponents/BulkHeader.vue";
+import BulkSingleEvent from "@/Pages/Projects/Components/BulkComponents/BulkSingleEvent.vue";
+import BulkBody from "@/Pages/Projects/Components/BulkComponents/BulkBody.vue";
+
+
+
+const props = defineProps({
+    project: {
+        type: Object,
+        required: true
+    },
+    event_types: {
+        type: Object,
+        required: true
+    },
+    rooms: {
+        type: Object,
+        required: true
+    }
+})
+
+
+</script>
+
+<style scoped>
+
+</style>

--- a/resources/js/Pages/Projects/Components/BulkComponents/BulkBody.vue
+++ b/resources/js/Pages/Projects/Components/BulkComponents/BulkBody.vue
@@ -1,0 +1,280 @@
+<template>
+    <div :class="!isInModal ? 'max-w-7xl my-10' : ''">
+
+        <div class="flex items-center justify-end" v-if="!isInModal">
+            <BaseMenu show-sort-icon dots-size="h-7 w-7" menu-width="w-72">
+                <MenuItem v-slot="{ active }">
+                    <div @click="updateSort(1)"
+                         :class="[active ? 'bg-artwork-navigation-color/10 text-white' : 'text-secondary', 'cursor-pointer group flex items-center justify-between px-4 py-2 text-sm subpixel-antialiased']">
+                        Nach Räumen sortieren
+                        <IconCheck class="w-5 h-5" v-if="currentSort === 1" />
+                    </div>
+                </MenuItem>
+                <MenuItem v-slot="{ active }">
+                    <div @click="updateSort(2)"
+                         :class="[active ? 'bg-artwork-navigation-color/10 text-white' : 'text-secondary', 'cursor-pointer group flex items-center justify-between px-4 py-2 text-sm subpixel-antialiased']">
+                        Nach Terminart sortieren
+                        <IconCheck class="w-5 h-5" v-if="currentSort === 2" />
+                    </div>
+                </MenuItem>
+                <MenuItem v-slot="{ active }">
+                    <div @click="updateSort(3)"
+                         :class="[active ? 'bg-artwork-navigation-color/10 text-white' : 'text-secondary', 'cursor-pointer group flex items-center justify-between px-4 py-2 text-sm subpixel-antialiased']">
+                        Nach Tag sortieren
+                        <IconCheck class="w-5 h-5" v-if="currentSort === 3" />
+                    </div>
+                </MenuItem>
+                <MenuItem v-slot="{ active }">
+                    <div @click="updateSort(0)"
+                         :class="[active ? 'bg-artwork-navigation-color/10 text-white' : 'text-secondary', 'cursor-pointer group flex items-center justify-between px-4 py-2 text-sm subpixel-antialiased']">
+                        Sortierung zurücksetzen
+                    </div>
+                </MenuItem>
+            </BaseMenu>
+        </div>
+
+        <BulkHeader v-model="timeArray" :is-in-modal="isInModal"/>
+        <div class="min-h-96 max-h-96 overflow-y-scroll">
+            <transition
+                enter-active-class="duration-300 ease-out"
+                enter-from-class="transform opacity-0"
+                enter-to-class="opacity-100"
+                leave-active-class="duration-200 ease-in"
+                leave-from-class="opacity-100"
+                leave-to-class="transform opacity-0">
+            <div>
+                <div v-for="(event, index) in events" class="mb-4">
+                    <BulkSingleEvent
+                        :rooms="rooms"
+                        :event_types="eventTypes"
+                        :time-array="timeArray"
+                        :event="event"
+                        :copy-types="copyTypes"
+                        :index="index"
+                        @delete-current-event="deleteCurrentEvent"
+                        @create-copy-by-event-with-data="createCopyByEventWithData"
+                    />
+                </div>
+            </div>
+            </transition>
+        </div>
+        <div class="flex items-center justify-between pointer-events-none">
+            <IconCirclePlus @click="addEmptyEvent" class="w-8 h-8 text-artwork-buttons-context cursor-pointer hover:text-artwork-buttons-hover transition-all duration-150 ease-in-out pointer-events-auto" stroke-width="2"/>
+
+            <div class="flex items-center gap-x-4">
+                <div v-if="invalidEvents.length > 0" class="text-artwork-messages-error text-xs">
+                    {{ $t('The name is not given for {0} event(s)', [invalidEvents.length]) }}
+                </div>
+                <BaseButton
+                    @click="submit"
+                    class="bg-artwork-buttons-create text-white h-12 pointer-events-auto"
+                    :text="$t('Create')">
+                    <IconCirclePlus class="w-5 h-5 text-white mr-2"/>
+                </BaseButton>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script setup>
+
+import BulkSingleEvent from "@/Pages/Projects/Components/BulkComponents/BulkSingleEvent.vue";
+import BaseButton from "@/Layouts/Components/General/Buttons/BaseButton.vue";
+import {IconCheck, IconCirclePlus} from "@tabler/icons-vue";
+import BulkHeader from "@/Pages/Projects/Components/BulkComponents/BulkHeader.vue";
+import {reactive, ref, watch} from "vue";
+import {router} from "@inertiajs/vue3";
+import BaseMenu from "@/Components/Menu/BaseMenu.vue";
+import {MenuItem} from "@headlessui/vue";
+
+const props = defineProps({
+    project: {
+        type: Object,
+        required: true
+    },
+    eventTypes: {
+        type: Array,
+        required: true
+    },
+    rooms: {
+        type: Object,
+        required: true
+    },
+    isInModal: {
+        type: Boolean,
+        required: false,
+        default: false
+    }
+})
+
+const timeArray = ref(!props.isInModal);
+const invalidEvents = ref([]);
+const emits = defineEmits(['closed']);
+const currentSort = ref(0);
+
+const copyTypes = ref([
+    {
+        id: 1,
+        name: 'Täglich',
+        type: 'daily'
+    },
+    {
+        id: 2,
+        name: 'Wöchentlich',
+        type: 'weekly'
+    },
+    {
+        id: 3,
+        name: 'Monatlich',
+        type: 'monthly',
+    }
+])
+
+const events = reactive([
+    {
+        index: 0,
+        type: props.eventTypes ? props.eventTypes[0] : null,
+        name: '',
+        room: props.rooms ? props.rooms[0] : null,
+        day: new Date().toISOString().split('T')[0],
+        start_time: '',
+        end_time: '',
+        copy: false,
+        copyCount: 1,
+        // default copy type is daily
+        copyType: copyTypes.value[0]
+    }
+])
+
+const addEmptyEvent = () => {
+    // create empty event but with +1 day of the last event
+    let newDate = new Date();
+    if (events.length > 0){
+        let lastEvent = events[events.length - 1];
+        newDate = new Date(lastEvent.day);
+        newDate.setDate(newDate.getDate() + 1);
+    }
+
+    events.push({
+        index: events.length + 1,
+        type: props.eventTypes ? props.eventTypes[0] : null,
+        name: '',
+        room: props.rooms ? props.rooms[0] : null,
+        day: newDate.toISOString().split('T')[0],
+        start_time: '',
+        end_time: '',
+        copy: false,
+        copyCount: 1,
+        copyType: copyTypes.value[0]
+    })
+}
+
+const deleteCurrentEvent = (event) => {
+    events.splice(events.indexOf(event), 1)
+}
+
+const updateTimeArray = (value) => {
+    timeArray.value = value;
+}
+
+const createCopyByEventWithData = (event) => {
+    let newDate = new Date(event.day);
+
+    for (let i = 0; i < event.copyCount; i++) {
+        // Je nach copyType den Tag anpassen
+        if (event.copyType.type === 'daily') {
+            newDate.setDate(newDate.getDate() + 1);
+        } else if (event.copyType.type === 'weekly') {
+            newDate.setDate(newDate.getDate() + 7);
+        } else if (event.copyType.type === 'monthly') {
+            newDate.setMonth(newDate.getMonth() + 1);
+        }
+
+        // Kopie des Events erstellen
+        events.push({
+            index: events.length + 1,
+            type: event.type,
+            name: event.name,
+            room: event.room,
+            day: newDate.toISOString().split('T')[0],
+            start_time: event.start_time,
+            end_time: event.end_time,
+            copy: false,
+            copyCount: 1,
+            copyType: copyTypes.value[0]
+        });
+    }
+
+    // copy flag zurücksetzen
+    event.copy = false;
+    event.copyCount = 1;
+    event.copyType = copyTypes.value[0];
+}
+
+const submit = () => {
+
+    // remove error flag from all events
+    events.forEach(event => {
+        event.nameError = false;
+    });
+
+    // check in every event if the type has a individual name flag if yes check if the name it not empty
+    invalidEvents.value = events.filter(event => event.type.individual_name && !event.name);
+
+    // if there are invalid events add a border to the input field, add error text and return
+    if (invalidEvents.value.length > 0) {
+        invalidEvents.value.forEach(event => {
+            event.nameError = true;
+        });
+        return;
+    }
+
+    router.post(route('events.bulk.store', {project: props.project}), {
+        events: events,
+    }, {
+        preserveScroll: true,
+        onSuccess: () => {
+            emits('closed');
+            // clear events
+            events.splice(0, events.length);
+            // add empty event
+            addEmptyEvent();
+        }
+    });
+
+}
+
+// add watch to event to check if the name was changed and remove the error flag and remove the event from the invalidEvents array
+watch(events, (newEvents) => {
+    newEvents.forEach(event => {
+        if (event.name) {
+            invalidEvents.value = invalidEvents.value.filter(invalidEvent => invalidEvent !== event);
+        }
+    });
+}, {deep: true});
+
+const updateSort = (type) => {
+    currentSort.value = type;
+    if (currentSort.value === 1) {
+        events.sort((a, b) => {
+            return a.room.name.localeCompare(b.room.name);
+        });
+    } else if (currentSort.value === 2) {
+        events.sort((a, b) => {
+            return a.type.name.localeCompare(b.type.name);
+        });
+    } else if (currentSort.value === 3) {
+        events.sort((a, b) => {
+            return a.day.localeCompare(b.day);
+        });
+    } else {
+        events.sort((a, b) => {
+            return a.index - b.index;
+        });
+    }
+}
+</script>
+
+<style scoped>
+
+</style>

--- a/resources/js/Pages/Projects/Components/BulkComponents/BulkHeader.vue
+++ b/resources/js/Pages/Projects/Components/BulkComponents/BulkHeader.vue
@@ -1,0 +1,74 @@
+<template>
+    <div class="grid gird-cols-1 md:grid-cols-8 gap-4 mb-3 text-gray-400 text-sm">
+        <div class="font-bold">
+            {{ $t('Event type') }}
+        </div>
+        <div class="font-bold">
+            {{ $t('Event name') }}
+        </div>
+        <div class="font-bold">
+            {{ $t('Room') }}
+        </div>
+        <div class="font-bold">
+            {{ $t('Day') }}
+        </div>
+        <div class="font-bold col-span-2">
+            <SwitchGroup as="div" class="flex items-center" v-if="isInModal">
+                <Switch v-model="localValue"
+                        @change="$emit('update:modelValue', localValue)"
+                        :class="[localValue ? 'bg-artwork-buttons-hover' : 'bg-gray-200', 'relative inline-flex h-4 w-9 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-0 focus:ring-indigo-600 focus:ring-offset-2']">
+                    <span aria-hidden="true"
+                          :class="[localValue ? 'translate-x-5' : 'translate-x-0', 'pointer-events-none inline-block h-3 w-3 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out']" />
+                </Switch>
+                <SwitchLabel as="span" class="ml-3">
+                    <div>
+                        {{ $t('Period') }}
+                    </div>
+                </SwitchLabel>
+            </SwitchGroup>
+            <div v-else>
+                {{ $t('Period') }}
+            </div>
+        </div>
+        <div class="font-bold">
+        </div>
+    </div>
+</template>
+
+<script setup>
+import {Switch, SwitchGroup, SwitchLabel} from "@headlessui/vue";
+import {ref, watch} from "vue";
+
+// Emit Event
+const emit = defineEmits(['update:modelValue']);
+
+// Props für v-model Unterstützung
+const props = defineProps({
+    modelValue: {
+        type: Boolean,
+        required: true
+    },
+    isInModal: {
+        type: Boolean,
+        required: false,
+        default: false
+    }
+});
+
+// Lokaler Wert, um den Zustand des Switches zu halten
+const localValue = ref(props.modelValue);
+
+// Watcher um Änderungen an modelValue zu berücksichtigen
+watch(() => props.modelValue, (newValue) => {
+    localValue.value = newValue;
+});
+
+// Wenn localValue geändert wird, das update:modelValue Event emittieren
+watch(localValue, (newValue) => {
+    emit('update:modelValue', newValue);
+});
+</script>
+
+<style scoped>
+/* Dein vorhandenes CSS */
+</style>

--- a/resources/js/Pages/Projects/Components/BulkComponents/BulkSingleEvent.vue
+++ b/resources/js/Pages/Projects/Components/BulkComponents/BulkSingleEvent.vue
@@ -1,0 +1,225 @@
+<template>
+   <div>
+       <div class="grid gird-cols-1 md:grid-cols-8 gap-4">
+           <div class="">
+               <Listbox as="div" class="" v-model="event.type" id="eventType">
+                   <ListboxButton class="menu-button">
+                       <div class="flex w-full justify-between">
+                           <div class="flex items-center gap-x-2">
+                               <div>
+                                   <div class="block w-5 h-5 rounded-full"
+                                        :style="{'backgroundColor' : event.type?.hex_code }"/>
+                               </div>
+                               <div>
+                                   {{ event.type?.name }}
+                               </div>
+                           </div>
+                           <IconChevronDown stroke-width="1.5" class="h-5 w-5 text-primary" aria-hidden="true"/>
+                       </div>
+                   </ListboxButton>
+
+                   <transition leave-active-class="transition ease-in duration-100" leave-from-class="opacity-100"
+                               leave-to-class="opacity-0">
+                       <ListboxOptions
+                           class="absolute w-72 z-10 bg-primary shadow-lg max-h-32 pr-2 pt-2 pb-2 text-base ring-1 ring-black ring-opacity-5 overflow-y-scroll focus:outline-none sm:text-sm">
+                           <ListboxOption as="template" class="max-h-8"
+                                          v-for="eventType in event_types"
+                                          :key="eventType.name"
+                                          :value="eventType"
+                                          v-slot="{ active, selected }">
+                               <li :class="[active ? ' text-white' : 'text-secondary', 'group hover:border-l-4 hover:border-l-success cursor-pointer flex justify-between items-center py-2 pl-3 pr-9 text-sm subpixel-antialiased']">
+                                   <div class="flex">
+                                       <div>
+                                           <div class="block w-3 h-3 rounded-full"
+                                                :style="{'backgroundColor' : eventType?.hex_code }"/>
+                                       </div>
+                                       <span
+                                           :class="[selected ? 'xsWhiteBold' : 'font-normal', 'ml-4 block truncate']">
+                                                        {{ eventType.name }}
+                                                    </span>
+                                   </div>
+                                   <span
+                                       :class="[active ? ' text-white' : 'text-secondary', ' group flex justify-end items-center text-sm subpixel-antialiased']">
+                                                      <IconCheck stroke-width="1.5" v-if="selected"
+                                                                 class="h-5 w-5 flex text-success"
+                                                                 aria-hidden="true"/>
+                                                </span>
+                               </li>
+                           </ListboxOption>
+                       </ListboxOptions>
+                   </transition>
+               </Listbox>
+           </div>
+           <div>
+               <input
+                   type="text"
+                   :id="'name-' + index"
+                   v-model="event.name"
+                   class="input h-12"
+                   :class="event.type?.individual_name && !event.name ? 'border-red-500' : ''"
+                   placeholder="Name"
+               />
+           </div>
+           <div>
+               <Listbox as="div" class="relative" v-model="event.room" id="room">
+                   <ListboxButton class="menu-button">
+                       <div class="flex-grow flex text-left xsDark">
+                           {{ event.room?.name }}
+                       </div>
+                       <IconChevronDown stroke-width="1.5" class="h-5 w-5 text-primary" aria-hidden="true"/>
+                   </ListboxButton>
+                   <ListboxOptions class="w-full rounded-lg bg-primary max-h-32 overflow-y-auto text-sm absolute z-30">
+                       <ListboxOption v-for="room in rooms"
+                                      class="hover:bg-indigo-800 text-secondary cursor-pointer p-2 flex justify-between"
+                                      :key="room.name"
+                                      :value="room"
+                                      v-slot="{ active, selected }">
+                           <div :class="[selected ? 'xsWhiteBold' : 'xsLight', 'flex']">
+                               {{ room.name }}
+                           </div>
+                           <IconCheck stroke-width="1.5" v-if="selected" class="h-5 w-5 text-success"
+                                      aria-hidden="true"/>
+                       </ListboxOption>
+                   </ListboxOptions>
+               </Listbox>
+           </div>
+           <div>
+               <input
+                   type="date"
+                   :id="'day-' + index"
+                   v-model="event.day"
+                   placeholder="Tag"
+                   class="input h-12"
+               />
+           </div>
+           <div class="col-span-2">
+               <div class="flex items-center" v-if="timeArray">
+                   <input
+                       type="time"
+                       :id="'start-time-' + index"
+                       v-model="event.start_time"
+                       placeholder="Tag"
+                       class="input h-12 !rounded-r-none"
+                   />
+                   <input
+                       type="time"
+                       :id="'end_time-' + index"
+                       v-model="event.end_time"
+                       placeholder="Tag"
+                       class="input h-12 !rounded-l-none border-l-0"
+                   />
+               </div>
+           </div>
+           <div class="flex items-center">
+               <div class="flex items-center gap-x-2">
+                   <IconCopy @click="event.copy = true" v-if="!event.copy"
+                             class="w-6 h-6 text-artwork-buttons-context cursor-pointer hover:text-artwork-buttons-hover transition-all duration-150 ease-in-out"
+                             stroke-width="2"/>
+                   <IconTrash v-if="index > 0 && !event.copy" @click="deleteCurrentEvent(event)"
+                              class="w-6 h-6 text-artwork-buttons-context cursor-pointer hover:text-artwork-messages-error transition-all duration-150 ease-in-out"
+                              stroke-width="2"/>
+                   <div v-if="event.copy" class="flex items-center gap-x-2">
+                       <IconPlus class="w-6 h-6 text-artwork-buttons-context" stroke-width="2"/>
+                       <input
+                           type="number"
+                           class="input h-12 w-14"
+                           placeholder="Anzahl"
+                           v-model="event.copyCount"
+                           min="1"
+                           minlength="1"
+                           max="1000"
+                       />
+                       <Listbox as="div" class="relative" v-model="event.copyType" id="room">
+                           <ListboxButton class="menu-button">
+                               <div class="flex-grow flex text-left xsDark !w-12 truncate">
+                                   {{ event.copyType?.name }}
+                               </div>
+                               <IconChevronDown stroke-width="1.5" class="h-5 w-5 text-primary" aria-hidden="true"/>
+                           </ListboxButton>
+                           <ListboxOptions
+                               class="w-full rounded-lg bg-primary max-h-32 overflow-y-auto text-sm absolute z-30">
+                               <ListboxOption v-for="copyType in copyTypes"
+                                              class="hover:bg-indigo-800 text-secondary cursor-pointer p-2 flex justify-between"
+                                              :key="copyType.name"
+                                              :value="copyType"
+                                              v-slot="{ active, selected }">
+                                   <div :class="[selected ? 'xsWhiteBold' : 'xsLight', 'flex']">
+                                       {{ copyType.name }}
+                                   </div>
+                                   <IconCheck stroke-width="1.5" v-if="selected" class="h-5 w-5 text-success"
+                                              aria-hidden="true"/>
+                               </ListboxOption>
+                           </ListboxOptions>
+                       </Listbox>
+                       <IconCircleCheckFilled @click="createCopyByEventWithData(event)"
+                                              class="w-8 h-8 text-artwork-buttons-create cursor-pointer hover:text-artwork-buttons-hover transition-all duration-150 ease-in-out"
+                                              stroke-width="2"/>
+                       <IconX @click="event.copy = false"
+                              class="w-6 h-6 text-artwork-buttons-context cursor-pointer hover:text-artwork-buttons-hover transition-all duration-150 ease-in-out"
+                              stroke-width="2"/>
+                   </div>
+               </div>
+           </div>
+       </div>
+       <div v-if="event.nameError && !event.name" class="text-xs mt-1 text-artwork-messages-error">
+           {{ $t('Event name is mandatory') }}
+       </div>
+   </div>
+</template>
+
+<script setup>
+
+import {
+    IconCheck,
+    IconChevronDown,
+    IconCircleCheckFilled,
+    IconCopy,
+    IconPlus,
+    IconTrash,
+    IconX
+} from "@tabler/icons-vue";
+import {Listbox, ListboxButton, ListboxOption, ListboxOptions} from "@headlessui/vue";
+import Input from "@/Layouts/Components/InputComponent.vue";
+
+const props = defineProps({
+    event: {
+        type: Object,
+        required: true
+    },
+    timeArray: {
+        type: Boolean,
+        required: true
+    },
+    event_types: {
+        type: Object,
+        required: true
+    },
+    rooms: {
+        type: Object,
+        required: true
+    },
+    copyTypes: {
+        type: Array,
+        required: true
+    },
+    index: {
+        type: Number,
+        required: true
+    }
+})
+
+const emit = defineEmits(['deleteCurrentEvent', 'createCopyByEventWithData']);
+
+const createCopyByEventWithData = (event) => {
+    emit('createCopyByEventWithData', event);
+}
+
+const deleteCurrentEvent = (event) => {
+    emit('deleteCurrentEvent', event);
+}
+
+</script>
+
+<style scoped>
+
+</style>

--- a/resources/js/Pages/Projects/ProjectManagement.vue
+++ b/resources/js/Pages/Projects/ProjectManagement.vue
@@ -136,7 +136,6 @@
                     <BasePaginator :entities="projects" property-name="projects" />
                 </div>
             </div>
-
         </div>
 
         <project-create-modal
@@ -150,6 +149,15 @@
             @close-create-project-modal="closeCreateProjectModal"
             :create-settings="createSettings"
             :project="null"
+        />
+
+
+        <AddBulkEventsModal
+            v-if="showAddBulkEventModal"
+            @closed="showAddBulkEventModal = false"
+            :project="myLastProject"
+            :event_types="eventTypes"
+            :rooms="rooms"
         />
 
         <!-- Success Modal - Delete project -->
@@ -260,9 +268,11 @@ import IconLib from "@/Mixins/IconLib.vue";
 import Input from "@/Jetstream/Input.vue";
 import Permissions from "@/Mixins/Permissions.vue";
 import projects from "@/Pages/Trash/Projects.vue";
+import AddBulkEventsModal from "@/Pages/Projects/Components/AddBulkEventsModal.vue";
 
 export default defineComponent({
     components: {
+        AddBulkEventsModal,
         BasePaginator,
         SingleProject,
         BaseModal,
@@ -296,7 +306,6 @@ export default defineComponent({
         ListboxOptions,
         CheckIcon,
         SelectorIcon,
-
         InformationCircleIcon,
         ChevronDownIcon,
         ChevronUpIcon,
@@ -326,7 +335,10 @@ export default defineComponent({
         'projectGroups',
         'first_project_tab_id',
         'pinnedProjects',
-        'createSettings'
+        'createSettings',
+        'myLastProject',
+        'eventTypes',
+        'rooms'
     ],
     mixins: [Permissions, IconLib],
     data() {
@@ -363,6 +375,7 @@ export default defineComponent({
             createProject: false,
             showProjectExportBudgetsByBudgetDeadlineModal: false,
             entitiesPerPage: [10, 15, 20, 30, 50, 75, 100],
+            showAddBulkEventModal: false
         }
     },
     computed: {
@@ -420,7 +433,8 @@ export default defineComponent({
         closeCreateProjectModal(showSuccessModal) {
             this.createProject = false;
             if (showSuccessModal) {
-                this.openSuccessModal2();
+                this.showAddBulkEventModal = true;
+                //this.openSuccessModal2();
             }
         },
         openEditProjectModal(project) {

--- a/resources/js/Pages/Projects/Tab/TabContent.vue
+++ b/resources/js/Pages/Projects/Tab/TabContent.vue
@@ -30,6 +30,7 @@ import ChecklistAllComponent from "@/Pages/Projects/Components/ChecklistAllCompo
 import CommentAllTab from "@/Pages/Projects/Tab/Components/CommentAllTab.vue";
 import BudgetInformations from "@/Pages/Projects/Tab/Components/BudgetInformations.vue";
 import {usePermission} from "@/Composeables/Permission.js";
+import BulkBody from "@/Pages/Projects/Components/BulkComponents/BulkBody.vue";
 
 const pageProps = usePage().props;
 provide('pageProps', pageProps);
@@ -61,7 +62,8 @@ const componentMapping = {
     ProjectAllDocumentsComponent,
     ChecklistAllComponent,
     CommentAllTab,
-    BudgetInformations
+    BudgetInformations,
+    BulkBody
 };
 
 const props = defineProps({
@@ -138,7 +140,7 @@ const removeML = (componentType) => {
                     :projectCategoryIds="headerObject.projectCategoryIds"
                     :projectGenreIds="headerObject.projectGenreIds"
                     :projectSectorIds="headerObject.projectSectorIds"
-                    :eventTypes="headerObject.eventTypes"
+                    :event-types="headerObject.eventTypes"
                     :opened_checklists="headerObject.project?.opened_checklists"
                     :checklist_templates="headerObject.project?.checklist_templates"
                     :projectManagerIds="headerObject.projectManagerIds"
@@ -146,6 +148,7 @@ const removeML = (componentType) => {
                     :first_project_tab_id="first_project_tab_id"
                     :first_project_calendar_tab_id="first_project_calendar_tab_id"
                     :first_project_budget_tab_id="first_project_budget_tab_id"
+                    :rooms="headerObject.rooms"
                 />
             </div>
         </div>
@@ -188,6 +191,7 @@ const removeML = (componentType) => {
                             :projectGenreIds="headerObject.projectGenreIds"
                             :projectSectorIds="headerObject.projectSectorIds"
                             :eventTypes="headerObject.eventTypes"
+                            :rooms="headerObject.rooms"
                         />
                     </div>
                 </div>

--- a/resources/js/Pages/Settings/Components/DragComponentElement.vue
+++ b/resources/js/Pages/Settings/Components/DragComponentElement.vue
@@ -32,7 +32,7 @@ export default {
             </div>
             <div class="text-center text-sm font-bold w-20">
                 <div class="w-20 truncate">
-                    {{ component.name }}
+                    {{ $t(component.name) }}
                     <div class="text-[10px] text-gray-500 font-light" v-if="component.data.height">
                         {{ component.data.height }} Pixel <span v-if="component.data.showLine === true">| {{ $t('Show a separator line')}}</span>
                     </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -297,6 +297,8 @@ Route::group(['middleware' => ['auth:sanctum', 'verified']], function (): void {
         ->name('projects.update_team');
     Route::get('/projects/{project}/export/budget', [ProjectController::class, 'projectBudgetExport'])
         ->name('projects.export.budget');
+    Route::post('/project/{project}/bulk/event/store', [EventController::class, 'bulkProjectEventStore'])
+        ->name('events.bulk.store');
 
     //ProjectTabs
     Route::get('/projects/{project}/tab/{projectTab}', [ProjectController::class, 'projectTab'])
@@ -1023,6 +1025,7 @@ Route::group(['middleware' => ['auth:sanctum', 'verified']], function (): void {
 
     // MultiEdit
     Route::patch('/multi-edit', [EventController::class, 'updateMultiEdit'])->name('multi-edit.save');
+    Route::patch('/multi-duplicate', [EventController::class, 'updateMultiDuplicate'])->name('multi-duplicate.save');
     Route::post('/multi-edit', [EventController::class, 'deleteMultiEdit'])->name('multi-edit.delete');
 
     // Calendar

--- a/tests/Unit/Artwork/Modules/Checklist/Http/Requests/ChecklistUpdateRequestTest.php
+++ b/tests/Unit/Artwork/Modules/Checklist/Http/Requests/ChecklistUpdateRequestTest.php
@@ -12,7 +12,7 @@ class ChecklistUpdateRequestTest extends TestCase
         self::assertSame([
             'user_id' => ['sometimes', 'nullable', 'exists:users,id'],
             'name' => ['sometimes', 'nullable', 'string'],
-
+            'private' => ['boolean'],
             'tasks' => ['sometimes', 'array'],
             'tasks.*.name' => ['sometimes', 'nullable', 'string'],
             'tasks.*.description' => ['sometimes', 'nullable', 'string'],

--- a/tests/Unit/Artwork/Modules/Event/Http/Requests/EventBulkCreateRequestTest.php
+++ b/tests/Unit/Artwork/Modules/Event/Http/Requests/EventBulkCreateRequestTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Unit\Artwork\Modules\Event\Http\Requests;
+
+use Artwork\Modules\Event\Http\Requests\EventBulkCreateRequest;
+use PHPUnit\Framework\TestCase;
+
+class EventBulkCreateRequestTest extends TestCase
+{
+    public function testRules(): void
+    {
+        self::assertSame(
+            [
+                'events' => 'required|array',
+                'events.*.name' => 'string',
+                'events.*.start_time' => 'nullable|date',
+                'events.*.end_time' => 'nullable|date',
+                'events.*.room' => 'array',
+                'events.*.room.id' => 'integer|exists:rooms,id',
+                'events.*.type' => 'array',
+                'events.*.type.id' => 'integer|exists:event_types,id',
+            ],
+            (new EventBulkCreateRequest())->rules()
+        );
+    }
+}


### PR DESCRIPTION
- Add mass creation for events for the last created project with buttons in the creation window 
- made some modals movable
  - new buttons for moving, removing the background and closing have been added here 
- add component for mass creation of events for the project tab system 
  - this component is by default in the "Schedule" tab in projects. 
- the calendar has been removed from the "Schedule" tab in projects
  - You can add the calendar component again in the project tab settings
- In the calendar, the days are now clearly separated from each other. 
- It is now possible to remove all selected dates from the multi-edit at the touch of a button without leaving the multi-edit 
- It is now possible to duplicate the selected dates in the multi-edit. 
