### PR TITLE
refs #ARTWORK-168-route-permissions-for-project-settings

### DIFF
--- a/artwork/Modules/Event/Services/EventService.php
+++ b/artwork/Modules/Event/Services/EventService.php
@@ -1069,7 +1069,6 @@ readonly class EventService
             $day,
             $event['start_time'] ?? null,
             $event['end_time'] ?? null
-
         );
 
         $project->events()->create([

--- a/routes/web.php
+++ b/routes/web.php
@@ -1237,7 +1237,9 @@ Route::group(['middleware' => ['auth:sanctum', 'verified']], function (): void {
 
     Route::group(['prefix' => 'settings'], function (): void {
         Route::group(['prefix' => 'tab'], function (): void {
-            Route::get('index', [ProjectTabController::class, 'index'])->name('tab.index');
+            Route::get('index', [ProjectTabController::class, 'index'])
+                ->name('tab.index')
+                ->middleware('role:artwork admin');
             Route::post('/{projectTab}/update/component/order', [ProjectTabController::class,
                 'updateComponentOrder'])
                 ->name('tab.update.component.order');
@@ -1276,7 +1278,8 @@ Route::group(['middleware' => ['auth:sanctum', 'verified']], function (): void {
         Route::group(['prefix' => 'component'], function (): void {
             // index
             Route::get('index', [ComponentController::class, 'index'])
-                ->name('component.index');
+                ->name('component.index')
+                ->middleware('role:artwork admin');
             // project.tab.component.update
             Route::patch('/{project}/{component}/update', [ProjectComponentValueController::class,
                 'update'])
@@ -1360,10 +1363,9 @@ Route::group(['middleware' => ['auth:sanctum', 'verified']], function (): void {
         )->name('user.calendar.abo.update');
     });
 
-    Route::group(['prefix' => 'project-roles'], function (): void {
-        Route::resource('project-roles', ProjectRoleController::class)
-            ->only(['index', 'store', 'update', 'destroy']);
-    });
+    Route::resource('project-roles', ProjectRoleController::class)
+        ->only(['index', 'store', 'update', 'destroy'])
+        ->middleware('role:artwork admin');
 
     // route for shift time preset
     Route::group(['prefix' => 'shift-time-preset'], function (): void {


### PR DESCRIPTION
- fix project-role route
- project-role route only accessible by admins
- settings/tab/index route only accessible by admins
- settings/component/index route only accessible by admins