### PR TITLE
add overbook function in shift component

### DIFF
--- a/app/Http/Controllers/ShiftQualificationController.php
+++ b/app/Http/Controllers/ShiftQualificationController.php
@@ -2,18 +2,23 @@
 
 namespace App\Http\Controllers;
 
+use Artwork\Modules\Shift\Models\Shift;
+use Artwork\Modules\Shift\Services\ShiftsQualificationsService;
 use Artwork\Modules\ShiftQualification\Http\Requests\StoreShiftQualificationRequest;
 use Artwork\Modules\ShiftQualification\Http\Requests\UpdateShiftQualificationRequest;
 use Artwork\Modules\ShiftQualification\Models\ShiftQualification;
 use Artwork\Modules\ShiftQualification\Services\ShiftQualificationService;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Redirect;
 use Throwable;
 
 class ShiftQualificationController extends Controller
 {
-    public function __construct()
+    public function __construct(
+        private ShiftsQualificationsService $shiftsQualificationsService
+    )
     {
         $this->authorizeResource(ShiftQualification::class, 'shift_qualification');
     }
@@ -59,5 +64,11 @@ class ShiftQualificationController extends Controller
             'success',
             ['shift_qualification' => __('flash-messages.shift-qualification.success.update')]
         );
+    }
+
+    public function updateValue(Shift $shift, Request $request): void
+    {
+        $this->shiftsQualificationsService
+            ->increaseValueOrCreateWithOneByQualification($shift->id, $request->integer('qualification_id'));
     }
 }

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -156,15 +156,10 @@ class UserController extends Controller
                     null
             );
         $users = MinimalUserIndexResource::collection(
-            User::query()->without(['calendar_settings', 'calendarAbo', 'shiftCalendarAbo'])->when(
-                strlen($search = $request->string('query')) > 0,
-                function (Builder $builder) use ($search): void {
-                    $builder->where('first_name', 'like', '%' . $search . '%')
-                        ->orWhere('last_name', 'like', '%' . $search . '%');
-                }
-            )->when(
-                !is_null($sortEnum),
-                function (Builder $builder) use ($sortEnum): void {
+            User::search($request->string('query')) // Meilisearch Integration
+            ->query(function (Builder $builder) use ($sortEnum): void {
+                // Hinzufügen der Abfragen für die Sortierung, falls nötig
+                if (!is_null($sortEnum)) {
                     switch ($sortEnum) {
                         case UserSortEnum::ALPHABETICALLY_ASCENDING:
                         case UserSortEnum::ALPHABETICALLY_DESCENDING:
@@ -179,8 +174,10 @@ class UserController extends Controller
                             break;
                     }
                 }
-            )->get()
+            })
+                ->get() // Hole die Ergebnisse aus Meilisearch
         )->resolve();
+
         if ($saveFilterAndSort) {
             $userUserManagementSettingService->updateOrCreateIfNecessary(
                 $userService->getAuthUser(),

--- a/artwork/Modules/Shift/Services/ShiftsQualificationsService.php
+++ b/artwork/Modules/Shift/Services/ShiftsQualificationsService.php
@@ -39,7 +39,7 @@ readonly class ShiftsQualificationsService
             //update existing shiftsQualification value based on parameters
             $this->shiftsQualificationsRepository->save(
                 $existingShiftsQualification->fill(
-                    ['value' => $shiftsQualification['value']]
+                    ['value' => $shiftsQualification['value'] ?? 0]
                 )
             );
         }
@@ -98,5 +98,33 @@ readonly class ShiftsQualificationsService
                 ['value' => $workerCount]
             );
         }
+    }
+
+    public function increaseValueOrCreateWithOneByQualification(int $shiftId, int $shiftQualificationId): void
+    {
+        /**
+         * @var ShiftsQualifications $existingShiftsQualifications
+         */
+        $existingShiftsQualifications = $this->shiftsQualificationsRepository->findByShiftIdAndShiftQualificationId(
+            $shiftId,
+            $shiftQualificationId
+        );
+
+        if (is_null($existingShiftsQualifications)) {
+            $this->createShiftsQualificationForShift(
+                $shiftId,
+                [
+                    'shift_qualification_id' => $shiftQualificationId,
+                    'value' => 1
+                ]
+            );
+
+            return;
+        }
+
+        $this->shiftsQualificationsRepository->update(
+            $existingShiftsQualifications,
+            ['value' => $existingShiftsQualifications->getAttribute('value') + 1]
+        );
     }
 }

--- a/artwork/Modules/User/Models/User.php
+++ b/artwork/Modules/User/Models/User.php
@@ -468,9 +468,22 @@ class User extends Model implements
     public function toSearchableArray(): array
     {
         return [
+            'id' => $this->id,
             'first_name' => $this->first_name,
-            'last_name' => $this->last_name
+            'last_name' => $this->last_name,
+            'full_name' => $this->first_name . ' ' . $this->last_name,
+            'profile_photo_url' => $this->profile_photo_url,
+            'profile_photo_path' => $this->profile_photo_path,
+            'position' => $this->position,
+            'business' => $this->business,
+            'phone_number' => $this->phone_number,
+            'email' => $this->email,
         ];
+    }
+
+    public function searchableAs(): string
+    {
+        return 'users_index';
     }
 
     /** @deprecated user WorkhourService */

--- a/database/seeders/WalidRaadSeeder.php
+++ b/database/seeders/WalidRaadSeeder.php
@@ -620,7 +620,7 @@ class WalidRaadSeeder extends Seeder
             [
                 'shift_id' => $shift->id,
                 'shift_qualification_id' => $workerShiftQualification->id,
-                'value' => fake()->numberBetween(0, 3) ?: null
+                'value' => fake()->numberBetween(1, 3) ?: null
             ]
         );
 
@@ -628,7 +628,7 @@ class WalidRaadSeeder extends Seeder
             [
                 'shift_id' => $shift->id,
                 'shift_qualification_id' => $masterShiftQualification->id,
-                'value' => fake()->numberBetween(0, 3) ?: null
+                'value' => fake()->numberBetween(1, 3) ?: null
             ]
         );
 
@@ -648,7 +648,7 @@ class WalidRaadSeeder extends Seeder
             [
                 'shift_id' => $shift->id,
                 'shift_qualification_id' => $workerShiftQualification->id,
-                'value' => fake()->numberBetween(0, 3) ?: null
+                'value' => fake()->numberBetween(1, 3) ?: null
             ]
         );
 
@@ -656,7 +656,7 @@ class WalidRaadSeeder extends Seeder
             [
                 'shift_id' => $shift->id,
                 'shift_qualification_id' => $masterShiftQualification->id,
-                'value' => fake()->numberBetween(0, 3) ?: null
+                'value' => fake()->numberBetween(1, 3) ?: null
             ]
         );
 
@@ -676,7 +676,7 @@ class WalidRaadSeeder extends Seeder
             [
                 'shift_id' => $shift->id,
                 'shift_qualification_id' => $workerShiftQualification->id,
-                'value' => fake()->numberBetween(0, 3) ?: null
+                'value' => fake()->numberBetween(1, 3) ?: null
             ]
         );
 
@@ -684,7 +684,7 @@ class WalidRaadSeeder extends Seeder
             [
                 'shift_id' => $shift->id,
                 'shift_qualification_id' => $masterShiftQualification->id,
-                'value' => fake()->numberBetween(0, 3) ?: null
+                'value' => fake()->numberBetween(1, 3) ?: null
             ]
         );
 
@@ -704,7 +704,7 @@ class WalidRaadSeeder extends Seeder
             [
                 'shift_id' => $shift->id,
                 'shift_qualification_id' => $workerShiftQualification->id,
-                'value' => fake()->numberBetween(0, 3) ?: null
+                'value' => fake()->numberBetween(1, 3) ?: null
             ]
         );
 
@@ -712,7 +712,7 @@ class WalidRaadSeeder extends Seeder
             [
                 'shift_id' => $shift->id,
                 'shift_qualification_id' => $masterShiftQualification->id,
-                'value' => fake()->numberBetween(0, 3) ?: null
+                'value' => fake()->numberBetween(1, 3) ?: null
             ]
         );
 

--- a/resources/js/Pages/Projects/Components/AddShiftQualificationToShiftModel.vue
+++ b/resources/js/Pages/Projects/Components/AddShiftQualificationToShiftModel.vue
@@ -1,0 +1,70 @@
+<template>
+    <BaseModal @closed="$emit('close')">
+        <div>
+            <ModalHeader
+                title="Add Qualification to Shift"
+                description="Füge eine Qualifikation zu dieser Schicht hinzu."
+            />
+            <p>
+                Schichtinformation:
+                {{ shift.craft.abbreviation }}
+                {{ shift.formatted_dates.start }} {{ shift.start }} -
+                {{ shift.formatted_dates.end }} {{ shift.end }}
+            </p>
+        </div>
+
+        <div class="mt-5">
+            <h3 class="font-semibold mb-2">
+                Wähle eine Qualifikation die du hinzufügen möchtest:
+            </h3>
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div v-for="qualification in shiftQualifications" :key="qualification.id">
+                    <button @click="addQualificationToShift(qualification.id)" class="text-center bg-artwork-buttons-create text-white hover:bg-artwork-buttons-hover transition-colors duration-300 ease-in-out w-full rounded-md px-3 py-2">
+                        <span class="flex items-center justify-center">
+                            {{ qualification.name }}
+                        </span>
+                    </button>
+                </div>
+            </div>
+        </div>
+    </BaseModal>
+</template>
+
+<script setup>
+
+import BaseModal from "@/Components/Modals/BaseModal.vue";
+import ModalHeader from "@/Components/Modals/ModalHeader.vue";
+import {router} from "@inertiajs/vue3";
+
+const props = defineProps({
+    shift: {
+        type: Object,
+        required: true
+    },
+    shiftQualifications: {
+        type: Object,
+        required: true
+    },
+})
+
+const emits = defineEmits([
+    'close'
+]);
+
+const addQualificationToShift = (qualificationId) => {
+    router.patch(route('shifts.qualifications.add', {shift: props.shift.id}), {
+        qualification_id: qualificationId
+    }, {
+        preserveScroll: true,
+        preserveState: true,
+        onSuccess: () => {
+            emits('close');
+        }
+    });
+}
+
+</script>
+
+<style scoped>
+
+</style>

--- a/resources/js/Pages/Projects/Components/SingleShift.vue
+++ b/resources/js/Pages/Projects/Components/SingleShift.vue
@@ -55,7 +55,7 @@
                 </div>
             </div>
         </div>
-        <div class="h-full mt-1 rounded-b-lg bg-gray-200 px-1 py-2">
+        <div class="mt-1 rounded-b-lg bg-gray-200 px-1 py-2 overflow-y-scroll h-full">
             <p class="text-xs mb-1">
                 <span v-if="shift.start_date && shift.end_date && shift.start_date !== shift.end_date">
                     {{ shift.formatted_dates.start }} {{ shift.start }} - {{ shift.formatted_dates.end }} {{ shift.end }}
@@ -159,6 +159,9 @@
                     @dropFeedback="dropFeedback"
                 />
             </div>
+            <div class="my-3 mx-0.5">
+                <component is="IconCirclePlus" @click="showAddShiftQualificationModal = true" class="h-5 w-5 xsLight cursor-pointer hover:text-artwork-buttons-hover transition-colors duration-300 ease-in-out" stroke-width="1.5" />
+            </div>
         </div>
     </div>
     <AddShiftModal v-if="openEditShiftModal"
@@ -174,6 +177,12 @@
     <ChooseDeleteUserShiftModal v-if="showDeleteUserModal"
                                 @close-modal="this.closeDeleteUserModal"
                                 @returnBuffer="deleteUserWithSeriesShiftData"
+    />
+    <AddShiftQualificationToShiftModel
+        v-if="showAddShiftQualificationModal"
+        @close="showAddShiftQualificationModal = false"
+        :shift="shift"
+        :shift-qualifications="shiftQualifications"
     />
 </template>
 <script>
@@ -194,10 +203,12 @@ import BaseMenu from "@/Components/Menu/BaseMenu.vue";
 import UserPopoverTooltip from "@/Layouts/Components/UserPopoverTooltip.vue";
 import ShiftNoteComponent from "@/Layouts/Components/ShiftNoteComponent.vue";
 import Permissions from "@/Mixins/Permissions.vue";
+import AddShiftQualificationToShiftModel from "@/Pages/Projects/Components/AddShiftQualificationToShiftModel.vue";
 
 export default defineComponent({
     name: "SingleShift",
     components: {
+        AddShiftQualificationToShiftModel,
         ShiftNoteComponent,
         UserPopoverTooltip,
         BaseMenu,
@@ -238,6 +249,7 @@ export default defineComponent({
             usersPivotIdToDelete: null,
             highlight: null,
             anyoneHasVacation: false,
+            showAddShiftQualificationModal: false
         }
     },
     mounted() {

--- a/routes/web.php
+++ b/routes/web.php
@@ -523,6 +523,10 @@ Route::group(['middleware' => ['auth:sanctum', 'verified']], function (): void {
         ->name('shift.preset.store');
     Route::post('/shifts/commit', [EventController::class, 'commitShifts'])->name('shifts.commit');
 
+    // patch shifts.qualifications.add
+    Route::patch('/shifts/{shift}/qualifications/add', [ShiftQualificationController::class, 'updateValue'])
+        ->name('shifts.qualifications.add');
+
     //EventTypes
     Route::get('/event_types', [EventTypeController::class, 'index'])
         ->name('event_types.management')


### PR DESCRIPTION
- A + (plus) can now be used to add an empty shift to the selected qualification in the shift component. 
- The search for users has been redesigned, now you can also search for the full name.  