### PR TITLE
Artwork 285 schichtzuordnung im projekttab

### DIFF
--- a/app/Http/Controllers/FreelancerController.php
+++ b/app/Http/Controllers/FreelancerController.php
@@ -172,7 +172,8 @@ class FreelancerController extends Controller
     {
         $this->authorize('updateWorkProfile', Freelancer::class);
 
-        $craftToAssign = Craft::find($request->get('craftId'));
+        $freelancer->assignedCrafts()->attach($request->get('craftId'));
+        /*$craftToAssign = Craft::find($request->get('craftId'));
 
         if (is_null($craftToAssign)) {
             return Redirect::back();
@@ -180,7 +181,7 @@ class FreelancerController extends Controller
 
         if (!$freelancer->assignedCrafts->contains($craftToAssign)) {
             $freelancer->assignedCrafts()->attach(Craft::find($request->get('craftId')));
-        }
+        }*/
 
         return Redirect::back();
     }

--- a/app/Http/Controllers/ServiceProviderController.php
+++ b/app/Http/Controllers/ServiceProviderController.php
@@ -140,7 +140,9 @@ class ServiceProviderController extends Controller
     {
         $this->authorize('updateWorkProfile', ServiceProvider::class);
 
-        $craftToAssign = Craft::find($request->get('craftId'));
+        $serviceProvider->assignedCrafts()->attach($request->get('craftId'));
+
+        /*$craftToAssign = Craft::find($request->get('craftId'));
 
         if (is_null($craftToAssign)) {
             return Redirect::back();
@@ -148,7 +150,7 @@ class ServiceProviderController extends Controller
 
         if (!$serviceProvider->assignedCrafts->contains($craftToAssign)) {
             $serviceProvider->assignedCrafts()->attach(Craft::find($request->get('craftId')));
-        }
+        }*/
 
         return Redirect::back();
     }

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -618,7 +618,7 @@ class UserController extends Controller
     {
         $this->authorize('updateWorkProfile', User::class);
 
-        $user->crafts()->attach($request->get('craftId'));
+        $user->assignedCrafts()->attach($request->get('craftId'));
 
         /*$craftToAssign = Craft::find();
 
@@ -640,7 +640,7 @@ class UserController extends Controller
     {
         $this->authorize('updateWorkProfile', User::class);
 
-        $user->crafts()->detach($craft);
+        $user->assignedCrafts()->detach($craft);
 
         return Redirect::back();
     }

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -618,7 +618,9 @@ class UserController extends Controller
     {
         $this->authorize('updateWorkProfile', User::class);
 
-        $craftToAssign = Craft::find($request->get('craftId'));
+        $user->crafts()->attach($request->get('craftId'));
+
+        /*$craftToAssign = Craft::find();
 
         if (is_null($craftToAssign)) {
             return Redirect::back();
@@ -626,7 +628,7 @@ class UserController extends Controller
 
         if (!$user->assignedCrafts->contains($craftToAssign)) {
             $user->assignedCrafts()->attach(Craft::find($request->get('craftId')));
-        }
+        }*/
 
         return Redirect::back();
     }
@@ -638,7 +640,7 @@ class UserController extends Controller
     {
         $this->authorize('updateWorkProfile', User::class);
 
-        $user->assignedCrafts()->detach($craft);
+        $user->crafts()->detach($craft);
 
         return Redirect::back();
     }

--- a/artwork/Modules/Craft/Models/Craft.php
+++ b/artwork/Modules/Craft/Models/Craft.php
@@ -70,20 +70,22 @@ class Craft extends Model
     }
 
     // Falls du die unterschiedlichen Typen spezifisch ansprechen möchtest:
-    public function users()
+    public function users(): \Illuminate\Database\Eloquent\Relations\MorphToMany
     {
         return $this->morphedByMany(User::class, 'craftable')->without([
             'calendar_settings', 'calendarAbo', 'shiftCalendarAbo'
-        ]);
+        ])->with(['shiftQualifications']);
     }
 
-    public function freelancers()
+    public function freelancers(): \Illuminate\Database\Eloquent\Relations\MorphToMany
     {
-        return $this->morphedByMany(Freelancer::class, 'craftable');
+        return $this->morphedByMany(Freelancer::class, 'craftable')
+            ->with(['shiftQualifications']);
     }
 
-    public function serviceProviders()
+    public function serviceProviders(): \Illuminate\Database\Eloquent\Relations\MorphToMany
     {
-        return $this->morphedByMany(ServiceProvider::class, 'craftable');
+        return $this->morphedByMany(ServiceProvider::class, 'craftable')
+            ->with(['shiftQualifications']);
     }
 }

--- a/artwork/Modules/Craft/Models/Craft.php
+++ b/artwork/Modules/Craft/Models/Craft.php
@@ -3,7 +3,9 @@
 namespace Artwork\Modules\Craft\Models;
 
 use Artwork\Core\Database\Models\Model;
+use Artwork\Modules\Freelancer\Models\Freelancer;
 use Artwork\Modules\InventoryManagement\Models\CraftInventoryCategory;
+use Artwork\Modules\ServiceProvider\Models\ServiceProvider;
 use Artwork\Modules\Shift\Models\Shift;
 use Artwork\Modules\User\Models\User;
 use Illuminate\Database\Eloquent\Builder;
@@ -45,10 +47,6 @@ class Craft extends Model
 
     protected $with = ['users'];
 
-    public function users(): BelongsToMany
-    {
-        return $this->belongsToMany(User::class, 'craft_users');
-    }
 
     public function scopeIsAssignableByAll(Builder $builder): Builder
     {
@@ -69,5 +67,23 @@ class Craft extends Model
         )
             ->orderBy('order')
             ->select(['id', 'craft_id', 'name', 'order']);
+    }
+
+    // Falls du die unterschiedlichen Typen spezifisch ansprechen möchtest:
+    public function users()
+    {
+        return $this->morphedByMany(User::class, 'craftable')->without([
+            'calendar_settings', 'calendarAbo', 'shiftCalendarAbo'
+        ]);
+    }
+
+    public function freelancers()
+    {
+        return $this->morphedByMany(Freelancer::class, 'craftable');
+    }
+
+    public function serviceProviders()
+    {
+        return $this->morphedByMany(ServiceProvider::class, 'craftable');
     }
 }

--- a/artwork/Modules/Freelancer/Models/Freelancer.php
+++ b/artwork/Modules/Freelancer/Models/Freelancer.php
@@ -20,6 +20,7 @@ use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Support\Collection;
 
 /**
@@ -114,9 +115,9 @@ class Freelancer extends Model implements Vacationer, Available, DayServiceable
         return $this->last_name . ', ' . $this->first_name;
     }
 
-    public function assignedCrafts(): BelongsToMany
+    public function assignedCrafts(): morphToMany
     {
-        return $this->belongsToMany(Craft::class, 'freelancer_assigned_crafts');
+        return $this->morphToMany(Craft::class, 'craftable');
     }
 
     /**

--- a/artwork/Modules/ProjectTab/Services/ProjectTabService.php
+++ b/artwork/Modules/ProjectTab/Services/ProjectTabService.php
@@ -121,7 +121,7 @@ class ProjectTabService implements ServiceWithArrayCache
                 )
             )
             ->setEventsWithRelevant($projectService->getEventsWithRelevantShifts($project))
-            ->setCrafts($craftService->getAll())
+            ->setCrafts($craftService->getAll(['users', 'freelancers', 'serviceProviders']))
             ->setCurrentUserCrafts($userService->getAuthUserCrafts()->merge($craftService->getAssignableByAllCrafts()))
             ->setShiftQualifications($shiftQualificationService->getAllOrderedByCreationDateAscending())
             ->setShiftTimePresets($this->shiftTimePresetService->getAll())

--- a/artwork/Modules/ServiceProvider/Models/ServiceProvider.php
+++ b/artwork/Modules/ServiceProvider/Models/ServiceProvider.php
@@ -18,6 +18,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Support\Collection;
 
 /**
@@ -87,9 +88,9 @@ class ServiceProvider extends Model implements DayServiceable
             ->withPivot('id', 'shift_qualification_id', 'craft_abbreviation');
     }
 
-    public function assignedCrafts(): BelongsToMany
+    public function assignedCrafts(): morphToMany
     {
-        return $this->belongsToMany(Craft::class, 'service_provider_assigned_crafts');
+        return $this->morphToMany(Craft::class, 'craftable');
     }
 
     public function shiftQualifications(): BelongsToMany

--- a/artwork/Modules/User/Http/Resources/UserWorkProfileResource.php
+++ b/artwork/Modules/User/Http/Resources/UserWorkProfileResource.php
@@ -31,7 +31,7 @@ class UserWorkProfileResource extends JsonResource
     // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClass
     public function toArray($request): array
     {
-        $assignedCrafts = $this->getAttribute('crafts');
+        $assignedCrafts = $this->getAttribute('assignedCrafts');
 
         return [
             'resource' => class_basename($this),
@@ -44,7 +44,7 @@ class UserWorkProfileResource extends JsonResource
             'can_work_shifts' => $this->getAttribute('can_work_shifts'),
             'accessibleCrafts' => $this->can('can plan shifts') ?
                 $this->crafts->filter(fn(Craft $craft) => $craft->getAttribute('assignable_by_all') === true)
-                    ->merge($this->getAttribute('crafts'))
+                    ->merge($this->getAttribute('assignedCrafts'))
                     ->toArray() :
                 [],
             'assignedCrafts' => $assignedCrafts,

--- a/artwork/Modules/User/Http/Resources/UserWorkProfileResource.php
+++ b/artwork/Modules/User/Http/Resources/UserWorkProfileResource.php
@@ -31,7 +31,7 @@ class UserWorkProfileResource extends JsonResource
     // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClass
     public function toArray($request): array
     {
-        $assignedCrafts = $this->getAttribute('assignedCrafts');
+        $assignedCrafts = $this->getAttribute('crafts');
 
         return [
             'resource' => class_basename($this),

--- a/artwork/Modules/User/Models/User.php
+++ b/artwork/Modules/User/Models/User.php
@@ -57,6 +57,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Foundation\Auth\Access\Authorizable;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Facades\Auth;
@@ -214,7 +215,8 @@ class User extends Model implements
     protected $appends = [
         'profile_photo_url',
         'full_name',
-        'type'
+        'type',
+        'assigned_craft_ids',
     ];
 
     protected $with = ['calendar_settings', 'calendarAbo', 'shiftCalendarAbo'];
@@ -242,10 +244,6 @@ class User extends Model implements
             urlencode($this->first_name . ' ' . $this->last_name) . '&color=7F9CF5&background=EBF4FF';
     }
 
-    public function crafts(): \Illuminate\Database\Eloquent\Relations\MorphToMany
-    {
-        return $this->morphToMany(Craft::class, 'craftable');
-    }
 
     public function shifts(): BelongsToMany
     {
@@ -404,9 +402,9 @@ class User extends Model implements
         return $this->hasOne(UserCommentedBudgetItemsSetting::class);
     }
 
-    public function assignedCrafts(): BelongsToMany
+    public function assignedCrafts(): morphToMany
     {
-        return $this->belongsToMany(Craft::class, 'users_assigned_crafts');
+        return $this->morphToMany(Craft::class, 'craftable');
     }
 
     public function shiftQualifications(): BelongsToMany

--- a/artwork/Modules/User/Models/User.php
+++ b/artwork/Modules/User/Models/User.php
@@ -242,9 +242,9 @@ class User extends Model implements
             urlencode($this->first_name . ' ' . $this->last_name) . '&color=7F9CF5&background=EBF4FF';
     }
 
-    public function crafts(): BelongsToMany
+    public function crafts(): \Illuminate\Database\Eloquent\Relations\MorphToMany
     {
-        return $this->belongsToMany(Craft::class, 'craft_users');
+        return $this->morphToMany(Craft::class, 'craftable');
     }
 
     public function shifts(): BelongsToMany

--- a/artwork/Modules/User/Services/UserService.php
+++ b/artwork/Modules/User/Services/UserService.php
@@ -133,7 +133,7 @@ class UserService
 
     public function getAuthUserCrafts(): Collection
     {
-        return $this->getAuthUser()->crafts;
+        return $this->getAuthUser()->assignedCrafts;
     }
 
     /**

--- a/database/migrations/2024_10_23_161924_craftable.php
+++ b/database/migrations/2024_10_23_161924_craftable.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('craftables', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('craft_id')->constrained()->onDelete('cascade');
+            $table->morphs('craftable'); // Fügt `craftable_id` und `craftable_type` hinzu
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('craftables');
+    }
+};

--- a/database/migrations/2024_10_25_150013_add_all_craft_user_to_new_table.php
+++ b/database/migrations/2024_10_25_150013_add_all_craft_user_to_new_table.php
@@ -17,17 +17,17 @@ return new class extends Migration
     {
         DB::table('users_assigned_crafts')
             ->orderBy('id')->each(function (\stdClass $craftable): void {
-                $this->insertToCraftable($craftable, User::class);
+                $this->insertToCraftable($craftable, User::class, $craftable->user_id);
             });
 
         DB::table('freelancer_assigned_crafts')
             ->orderBy('id')->each(function (\stdClass $craftable): void {
-                $this->insertToCraftable($craftable, Freelancer::class);
+                $this->insertToCraftable($craftable, Freelancer::class, $craftable->freelancer_id);
             });
 
         DB::table('service_provider_assigned_crafts')
             ->orderBy('id')->each(function (\stdClass $craftable): void {
-                $this->insertToCraftable($craftable, ServiceProvider::class);
+                $this->insertToCraftable($craftable, ServiceProvider::class, $craftable->service_provider_id);
             });
     }
 
@@ -40,13 +40,13 @@ return new class extends Migration
     }
 
 
-    private function insertToCraftable(\stdClass $model, string $baseClass): void
+    private function insertToCraftable(\stdClass $model, string $baseClass, int $modelId): void
     {
         DB::table('craftables')
             ->insert([
                 'craft_id' => $model->craft_id,
                 'craftable_type' => $baseClass,
-                'craftable_id' => $model->service_provider_id,
+                'craftable_id' => $modelId,
             ]);
     }
 };

--- a/database/migrations/2024_10_25_150013_add_all_craft_user_to_new_table.php
+++ b/database/migrations/2024_10_25_150013_add_all_craft_user_to_new_table.php
@@ -1,0 +1,52 @@
+<?php
+
+use Artwork\Modules\Freelancer\Models\Freelancer;
+use Artwork\Modules\ServiceProvider\Models\ServiceProvider;
+use Artwork\Modules\User\Models\User;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        DB::table('users_assigned_crafts')
+            ->orderBy('id')->each(function (\stdClass $craftable): void {
+                $this->insertToCraftable($craftable, User::class);
+            });
+
+        DB::table('freelancer_assigned_crafts')
+            ->orderBy('id')->each(function (\stdClass $craftable): void {
+                $this->insertToCraftable($craftable, Freelancer::class);
+            });
+
+        DB::table('service_provider_assigned_crafts')
+            ->orderBy('id')->each(function (\stdClass $craftable): void {
+                $this->insertToCraftable($craftable, ServiceProvider::class);
+            });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+
+    }
+
+
+    private function insertToCraftable(\stdClass $model, string $baseClass): void
+    {
+        DB::table('craftables')
+            ->insert([
+                'craft_id' => $model->craft_id,
+                'craftable_type' => $baseClass,
+                'craftable_id' => $model->service_provider_id,
+            ]);
+    }
+};

--- a/lang/de.json
+++ b/lang/de.json
@@ -2050,5 +2050,6 @@
     "Delete Entries": "Einträge löschen",
     "Delete Entries & new Entries": "Einträge löschen & neue Einträge",
     "h/week as per contract": "h/Woche lt. Vertrag",
-    "Business": "Geschäftlich"
+    "Business": "Geschäftlich",
+    "Updating...": "Aktualisiere..."
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -2050,5 +2050,6 @@
     "Delete Entries": "Delete Entries",
     "Delete Entries & new Entries": "Delete Entries & new Entries",
     "h/week as per contract": "h/week as per contract",
-    "Business": "Business"
+    "Business": "Business",
+    "Updating...": "Updating..."
 }

--- a/resources/js/Components/Calendar/Elements/SingleEventInCalendar.vue
+++ b/resources/js/Components/Calendar/Elements/SingleEventInCalendar.vue
@@ -418,7 +418,7 @@ const props = defineProps({
         required: true
     },
     firstProjectShiftTabId: {
-        type: Number,
+        type: [Number, String],
         required: false,
         default: null
     }

--- a/resources/js/Components/Filter/CraftFilter.vue
+++ b/resources/js/Components/Filter/CraftFilter.vue
@@ -43,7 +43,7 @@ export default {
     <div class="my-3">
         <div>
             <div class="h-9 flex items-center cursor-pointer" @click="showCraftFilter = !showCraftFilter">
-                <div class=""  :class="is_tiny ? 'flex items-center text-white text-xs' : 'flex w-full py-2 justify-between rounded-lg text-left text-sm font-medium focus:outline-none focus-visible:ring-purple-500'">
+                <div class="" :class="is_tiny ? 'flex items-center text-white text-xs' : 'flex w-full py-2 justify-between rounded-lg text-left text-sm font-medium focus:outline-none focus-visible:ring-purple-500'">
                     {{ $t('Crafts') }}
 
                     <IconChevronDown v-if="!showCraftFilter" class="w-4 h-4 ml-2"/>
@@ -55,7 +55,7 @@ export default {
                 <div v-for="craft in crafts" :key="craft.id">
                     <div class="relative flex items-start mb-2">
                         <div class="flex h-6 items-center">
-                            <input @change="addCraftToUser(craft.id)" :id="'craft-' + craft.id" :checked="selectedCrafts?.includes(craft.id)" aria-describedby="comments-description" name="comments" type="checkbox" class="input-checklist" />
+                            <input @change="addCraftToUser(craft.id)" :id="'craft-' + craft.id" :checked="selectedCrafts?.includes(craft.id)" aria-describedby="comments-description" name="comments" type="checkbox" class="input-checklist-dark" />
                         </div>
                         <div class="ml-2 text-sm leading-6">
                             <label :for="'craft-' + craft.id" class="font-medium text-white">{{ craft.name }}</label>

--- a/resources/js/Components/Inputs/DateInputComponent.vue
+++ b/resources/js/Components/Inputs/DateInputComponent.vue
@@ -35,7 +35,7 @@ export default defineComponent({
             required: true
         },
         modelValue: {
-            type: String,
+            type: [String, null],
             required: true
         },
         noMarginTop: {

--- a/resources/js/Components/Inputs/NumberInputComponent.vue
+++ b/resources/js/Components/Inputs/NumberInputComponent.vue
@@ -32,7 +32,7 @@ export default defineComponent({
             required: true
         },
         modelValue: {
-            type: String,
+            type: [String, null, Number],
             required: true
         },
         isSmall: {

--- a/resources/js/Components/Inputs/TextInputComponent.vue
+++ b/resources/js/Components/Inputs/TextInputComponent.vue
@@ -33,7 +33,7 @@ export default defineComponent({
             required: true
         },
         modelValue: {
-            type: String,
+            type: [String, null],
             required: true
         },
         isSmall: {

--- a/resources/js/Components/Inputs/TextareaComponent.vue
+++ b/resources/js/Components/Inputs/TextareaComponent.vue
@@ -37,7 +37,7 @@ export default defineComponent({
             required: true
         },
         modelValue: {
-            type: String,
+            type: [String, null],
             required: true
         },
         isSmall: {

--- a/resources/js/Components/Inputs/TextareaComponent.vue
+++ b/resources/js/Components/Inputs/TextareaComponent.vue
@@ -49,7 +49,7 @@ export default defineComponent({
             default: false
         },
         rows: {
-            type: Number,
+            type: [Number, String],
             default: 3
         },
         cols: {

--- a/resources/js/Components/Inputs/TimeInputComponent.vue
+++ b/resources/js/Components/Inputs/TimeInputComponent.vue
@@ -37,7 +37,7 @@ export default defineComponent({
             default: false
         },
         modelValue: {
-            type: String,
+            type: [String, null],
             required: true
         },
         isSmall: {

--- a/resources/js/Components/Menu/BaseMenu.vue
+++ b/resources/js/Components/Menu/BaseMenu.vue
@@ -1,7 +1,6 @@
 <template>
-
     <Menu as="div" class="inline-block" :class="!noRelative ? 'relative' : ''">
-        <Float auto-placement portal  :offset="{ mainAxis: -10, crossAxis: 75}">
+        <Float auto-placement portal :offset="{ mainAxis: -10, crossAxis: 75}">
             <div class="font-semibold text-artwork-buttons-context flex items-center justify-center" ref="menuButtonRef">
                 <MenuButton>
                     <IconDotsVertical

--- a/resources/js/Components/Modals/BaseModal.vue
+++ b/resources/js/Components/Modals/BaseModal.vue
@@ -100,6 +100,7 @@ export default {
                 console.error('containerRef is not a valid DOM element');
             }
         });
+        document.body.click();
     },
     emits: ['closed'],
     methods: {

--- a/resources/js/Composeables/UseColorHelper.js
+++ b/resources/js/Composeables/UseColorHelper.js
@@ -33,6 +33,11 @@ export function useColorHelper() {
         }
     }
 
+    function backgroundColorWithOpacityOld(color, percent = 15) {
+        if (!color) return `rgba(255, 255, 255, ${percent / 100})`;
+        return `rgba(${parseInt(color.slice(-6, -4), 16)}, ${parseInt(color.slice(-4, -2), 16)}, ${parseInt(color.slice(-2), 16)}, ${percent / 100})`;
+    }
+
     function getTextColorBasedOnBackground(color) {
         const isDark = isDarkColor(color);
         return isDark ? '#FFFFFF' : '#000000';
@@ -53,6 +58,7 @@ export function useColorHelper() {
         detectParentBackgroundColor,
         getTextColorBasedOnBackground,
         isDarkColor,
-        parentBackgroundColor
+        parentBackgroundColor,
+        backgroundColorWithOpacityOld
     };
 }

--- a/resources/js/Helper/ShiftPlanPlacementHandler.vue
+++ b/resources/js/Helper/ShiftPlanPlacementHandler.vue
@@ -506,7 +506,9 @@ export default class {
             hintElement = existingHintElement;
         }
 
+        /*
         hintElement.innerText = '--- Ungenutzt: ' + innerTextTime + ' ---';
+        */
 
         if (!existingHintElement) {
             //if previous is a timeline and current too we need to add a margin top for diff hint placement

--- a/resources/js/Layouts/Components/SingleRoomCalendarComponent.vue
+++ b/resources/js/Layouts/Components/SingleRoomCalendarComponent.vue
@@ -14,9 +14,6 @@
                 <ExclamationIcon class="h-6  mr-2"/>
                 {{ filteredEvents?.length === 1 ? $t('{0} Event without room!', [filteredEvents?.length]) : $t('{0} Events without room!', [filteredEvents?.length]) }}
             </div>
-            <pre>
-
-            </pre>
             <!-- Calendar -->
             <table class="w-full flex flex-wrap bg-white">
                 <tbody class="flex w-full flex-wrap">

--- a/resources/js/Layouts/Components/TagComponent.vue
+++ b/resources/js/Layouts/Components/TagComponent.vue
@@ -32,7 +32,7 @@ export default {
     mixins: [ColorHelper],
     props: {
         property: {
-            type: Object,
+            type: [Object, String],
             required: false,
             default: null
         },

--- a/resources/js/Layouts/Components/TagComponent.vue
+++ b/resources/js/Layouts/Components/TagComponent.vue
@@ -32,7 +32,7 @@ export default {
     mixins: [ColorHelper],
     props: {
         property: {
-            type: [Object, String],
+            type: [Object, String, Number],
             required: false,
             default: null
         },

--- a/resources/js/Layouts/Components/UserPopoverTooltip.vue
+++ b/resources/js/Layouts/Components/UserPopoverTooltip.vue
@@ -1,7 +1,7 @@
 <template>
-    <Popover v-slot="{ open }" class="!ring-0 -mb-1 -pb-1">
+    <Popover v-slot="{ open }" class="!ring-0">
         <PopoverButton :class="open ? '' : 'text-opacity-90'"
-                       class="group inline-flex !ring-0 outline-0 -mb-1"
+                       class="group inline-flex !ring-0 outline-0"
                        @click="calculatePopoverPosition">
             <template v-if="useSlotInsteadOfIcon">
                 <slot/>

--- a/resources/js/Pages/Auth/Login.vue
+++ b/resources/js/Pages/Auth/Login.vue
@@ -64,59 +64,6 @@
             <img class="h-screen w-full object-cover" :src="$page.props.banner" alt=""/>
         </div>
     </div>
-
-
-
-    <div class="min-h-full hidden">
-        <img :src="$page.props.big_logo" class="w-20 h-20 ml-12 mt-12 absolute rounded-full" />
-        <div
-            class="flex-1 flex min-h-screen flex-col align-items-center justify-center py-12 px-4 sm:px-6 lg:px-20 xl:px-24">
-            <div class="mx-auto  w-full max-w-sm lg:w-96">
-
-
-
-                <div class="mt-8">
-                    <div class="mt-6">
-                        <form class="space-y-6" @submit.prevent="submit">
-                            <div class="relative w-full mr-4">
-                                <input id="email" v-model="form.email" type="text" class="peer pl-0 h-12 w-full focus:border-t-transparent focus:border-primary focus:ring-0 border-l-0 border-t-0 border-r-0 border-b-2 border-gray-300 text-primary placeholder-secondary placeholder-transparent" placeholder="placeholder" />
-                                <label for="email" class="absolute left-0 text-sm -top-5 text-gray-600 text-sm -top-3.5 transition-all subpixel-antialiased focus:outline-none text-secondary peer-placeholder-shown:text-base peer-placeholder-shown:text-gray-400 peer-placeholder-shown:top-2 peer-focus:-top-3.5 peer-focus:text-sm ">{{$t('Email')}}*</label>
-                            </div>
-
-                            <div class="relative w-full mr-4">
-                                <input id="password" v-model="form.password" type="password" class="peer pl-0 h-12 w-full focus:border-t-transparent focus:border-primary focus:ring-0 border-l-0 border-t-0 border-r-0 border-b-2 border-gray-300 text-primary placeholder-secondary placeholder-transparent" placeholder="placeholder" />
-                                <label for="password" class="absolute left-0 text-sm -top-5 text-gray-600 text-sm -top-3.5 transition-all subpixel-antialiased focus:outline-none text-secondary peer-placeholder-shown:text-base peer-placeholder-shown:text-gray-400 peer-placeholder-shown:top-2 peer-focus:-top-3.5 peer-focus:text-sm ">{{ $t('Password')}}*</label>
-                            </div>
-                            <jet-input-error :message="errors.email" class="mt-2"/>
-                            <div class="flex items-center justify-between">
-                                <div class="flex items-center">
-                                    <Checkbox class="justify-between text-sm" :item=rememberCheckbox />
-                                </div>
-                                <div class="text-sm">
-                                    <Link v-if="canResetPassword" :href="route('password.request')"
-                                          class="text-xs text-secondary subpixel-antialiased hover:font-semibold hover:text-primary">
-                                        {{$t('Forgot your password?')}}
-                                    </Link>
-                                </div>
-                            </div>
-
-
-                            <div>
-                                <BaseButton :text="$t('Login')" :disabled="this.form.email === '' || this.form.password === ''" horizontal-padding="px-44" vertical-padding="py-4" type="submit" />
-                            </div>
-                        </form>
-
-                    </div>
-                </div>
-
-            </div>
-        </div>
-        <div class="hidden lg:block relative w-0 flex-1">
-            <img class="absolute inset-0 h-full w-full object-cover"
-                 :src="$page.props.banner"
-                 alt=""/>
-        </div>
-    </div>
 </template>
 
 <script>

--- a/resources/js/Pages/Branding/Index.vue
+++ b/resources/js/Pages/Branding/Index.vue
@@ -44,7 +44,7 @@
                 {{ $t(form.errors?.bigLogo) }}
             </div>
             <label class="block mt-12 mb-4 xsDark">
-                {{ $t('Small Logo (Upload by click or drag & drop') }}
+                {{ $t('Small Logo (Upload by click or drag & drop)') }}
             </label>
             <div class="grid grid-cols-6 gap-x-12 items-center">
                 <div

--- a/resources/js/Pages/Contracts/ContractManagement.vue
+++ b/resources/js/Pages/Contracts/ContractManagement.vue
@@ -113,8 +113,8 @@
             </div>
         </div>
 
-        <BaseSidenav :show="show" @toggle="this.show =! this.show">
-            <ContractModuleSidenav :contractModules="contract_modules" @upload="this.show = true" />
+        <BaseSidenav>
+            <ContractModuleSidenav :contractModules="contract_modules" />
         </BaseSidenav>
 
         <ContractUploadModal
@@ -177,7 +177,6 @@ export default {
     ],
     data() {
         return {
-            show: false,
             //filters: {},
             costNames: [],
             companyTypeNames: [],

--- a/resources/js/Pages/Events/EventManagement.vue
+++ b/resources/js/Pages/Events/EventManagement.vue
@@ -9,7 +9,6 @@
                               :events-without-room="eventsWithoutRoom"
                               :projectNameUsedForProjectTimePeriod="projectNameUsedForProjectTimePeriod"
                               :first-project-shift-tab-id="first_project_shift_tab_id"
-                              :firstProjectCalendarTabId="first_project_calendar_tab_id"
                 />
 
                 <IndividualCalendarAtGlanceComponent v-else

--- a/resources/js/Pages/Interfaces/Index.vue
+++ b/resources/js/Pages/Interfaces/Index.vue
@@ -8,7 +8,7 @@
             <div class="flex items-center justify-end col-span-3">
                 <div class="flex items-center mr-2">
                     <span class="ml-1 my-auto hind">{{ $t('Execute data retrieval from Sage again') }}&nbsp;</span>
-                    <SvgCollection svgName="smallArrowRight" class="h-6 w-6 ml-2 mr-2"/>
+                    <component is="IconArrowCurveRight" class="h-6 w-6 ml-1 mr-1 rotate-90 hind" stroke-width="1.7"/>
                 </div>
                 <RefreshIcon :class="[
                                 !this.sageInterfaceIsConfigured() || this.importProcessing ?

--- a/resources/js/Pages/Projects/Components/AddShiftModal.vue
+++ b/resources/js/Pages/Projects/Components/AddShiftModal.vue
@@ -466,9 +466,6 @@ export default defineComponent({
             if (((shiftEndDateTime - shiftStartDateTime) / 60000) > 600) {
                 this.validationMessages.warnings.shift_start.push(this.$t('The shift is over 10 hours long!'));
             }
-            if (shiftEndDateTime > eventEndDateTime) {
-                this.validationMessages.warnings.shift_end.push(this.$t('The shift ends after the event ends!'));
-            }
             if (shiftStartDateTime > shiftEndDateTime) {
                 this.validationMessages.warnings.shift_end.push(this.$t('The shift ends before it starts!'));
             }

--- a/resources/js/Pages/Projects/Components/DragElement.vue
+++ b/resources/js/Pages/Projects/Components/DragElement.vue
@@ -33,7 +33,7 @@
             </div>
 
         </div>
-        <div class="flex items-center justify-end w-full gap-2 absolute right-2 top-2">
+        <div class="flex items-center justify-end w-fit gap-2 absolute right-2 top-2">
             <div v-if="type === 0 && item.is_freelancer || type === 1">
                 <ToolTipComponent
                     icon="IconId"

--- a/resources/js/Pages/Projects/Components/DragElement.vue
+++ b/resources/js/Pages/Projects/Components/DragElement.vue
@@ -1,6 +1,6 @@
 
 <template>
-    <div :class="[$page.props.user.compact_mode ? 'h-8 flex items-center justify-between' : 'h-12']" class="drag-item w-full p-2 text-white text-xs rounded-lg flex items-center gap-2" draggable="true" @dragstart="onDragStart"  :style="{backgroundColor: backgroundColorWithOpacity(color)}">
+    <div :class="[$page.props.user.compact_mode ? 'h-8 flex items-center justify-between' : 'h-12']" class="drag-item w-full p-2 text-white text-xs rounded-lg flex items-center gap-2 relative" draggable="true" @dragstart="onDragStart"  :style="{backgroundColor: backgroundColorWithOpacity(color)}">
         <div class="text-white" v-if="!$page.props.user.compact_mode">
             <img :src="item.profile_photo_url" alt="" class="h-6 w-6 rounded-full object-cover min-w-6 min-h-6">
         </div>

--- a/resources/js/Pages/Projects/Components/MultipleShiftQualificationSlotsAvailable.vue
+++ b/resources/js/Pages/Projects/Components/MultipleShiftQualificationSlotsAvailable.vue
@@ -1,5 +1,5 @@
 <template>
-    <BaseModal @closed="close" v-if="show" modal-image="/Svgs/Overlays/illu_user_invite.svg">
+    <BaseModal @closed="close(null, null, null, true)" v-if="show" modal-image="/Svgs/Overlays/illu_user_invite.svg">
             <div class="mx-4">
                 <ModalHeader
                     :title="$t('Select qualification')"
@@ -42,8 +42,8 @@ export default defineComponent({
         'close'
     ],
     methods: {
-        close(event, droppedUser = null, shiftQualificationId = null) {
-            this.$emit('close', droppedUser, shiftQualificationId);
+        close(event, droppedUser = null, shiftQualificationId = null, closeOnButton = false) {
+            this.$emit('close', droppedUser, shiftQualificationId, closeOnButton);
         }
     }
 });

--- a/resources/js/Pages/Projects/Components/SelectUserForShiftMenu.vue
+++ b/resources/js/Pages/Projects/Components/SelectUserForShiftMenu.vue
@@ -1,0 +1,212 @@
+<template>
+    <Menu as="div" class="w-full h-full" v-slot="{ open }" :open="menuOpen" @close="menuOpen = false">
+        <Float auto-placement portal>
+            <div class="w-full h-full">
+                <MenuButton class="w-full h-full">
+                    <slot></slot>
+                </MenuButton>
+            </div>
+
+            <transition enter-active-class="transition ease-out duration-100"
+                        enter-from-class="transform opacity-0 scale-95"
+                        enter-to-class="transform opacity-100 scale-100"
+                        leave-active-class="transition ease-in duration-75"
+                        leave-from-class="transform opacity-100 scale-100"
+                        leave-to-class="transform opacity-0 scale-95">
+                <MenuItems class="rounded-lg absolute bg-artwork-navigation-background shadow-xl ring-1 ring-black ring-opacity-5 focus:outline-none w-64 h-fit overflow-y-scroll">
+                    <div class="text-white">
+                        <div class=" px-3 py-5">
+                            <div class="flex items-center justify-between">
+                                <div class="flex gap-4 items-center" @click="openOrCloseFilter">
+                                    <span class="flex" v-if="openFilter">
+                                        <IconFilter class="h-5 w-5 text-white"/>
+                                       <IconChevronDown class="h-5 w-5 text-white"/>
+                                    </span>
+                                    <span class="flex" v-else>
+                                        <IconFilter class="h-5 w-5 text-white"/>
+                                        <IconChevronUp class="h-5 w-5 text-white"/>
+                                    </span>
+                                </div>
+                            </div>
+                            <div class="" v-if="openFilter">
+                                <div class="my-5">
+                                    <div class="flex w-full mb-3">
+                                        <input v-model="showIntern"
+                                               type="checkbox"
+                                               class="input-checklist-dark"/>
+                                        <div :class="[showIntern ? 'xsWhiteBold' : 'xsLight', 'my-auto ml-2']">
+                                            {{ $t('Internal employees') }}
+                                        </div>
+                                    </div>
+                                    <div class="flex w-full mb-3">
+                                        <input v-model="showExtern"
+                                               type="checkbox"
+                                               class="input-checklist-dark"/>
+                                        <div :class="[showExtern ? 'xsWhiteBold' : 'xsLight', 'my-auto ml-2']">
+                                            {{ $t('External employees') }}
+                                        </div>
+                                    </div>
+                                    <div class="flex w-full mb-3">
+                                        <input v-model="showProvider"
+                                               type="checkbox"
+                                               class="input-checklist-dark"/>
+                                        <div :class="[showProvider ? 'xsWhiteBold' : 'xsLight', 'my-auto ml-2']">
+                                            {{ $t('Service provider') }}
+                                        </div>
+                                    </div>
+                                    <div>
+                                        <div>
+                                            <label for="account-number" class="block text-xs font-medium leading-6 text-white">
+                                                {{ $t('Search') }}
+                                            </label>
+                                            <div class="relative mt-2 rounded-md shadow-sm">
+                                                <input v-model="userSearch" ref="searchFieldUserSearch" type="text" name="account-number" id="account-number" class="block w-full rounded-lg border border-gray-600 py-1.5 pr-10 text-white ring-0 bg-darkGrayBg placeholder:text-gray-400 focus:border-gray-500 focus:ring-0 sm:text-sm sm:leading-6" />
+                                                <div class="absolute inset-y-0 right-0 flex items-center pr-3">
+                                                    <IconSearch class="h-5 w-5 text-gray-400" aria-hidden="true" v-if="userSearch.length === 0" />
+                                                    <IconX class="h-5 w-5 text-gray-400 cursor-pointer" aria-hidden="true" v-if="userSearch.length > 0" @click="userSearch = ''"/>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="my-2 h-0.5 w-full bg-[#3A374D]">
+                                </div>
+                            </div>
+                        </div>
+                        <div class="max-h-72 overflow-y-scroll pl-3 pb-5">
+                            <div v-for="craft in craftWithUserFilteredByName" class="mt-1">
+                                <div @click="changeCraftVisibility(craft.id)" class="text-xs text-white flex cursor-pointer items-center h-6" v-if="craft.users.length > 0">
+                                    {{ craft.name }}
+                                    <IconChevronDown
+                                        :class="closedCrafts.includes(craft.id) ? '' : 'rotate-180 transform'"
+                                        class="h-4 w-4"
+                                    />
+                                </div>
+                                <div v-for="user in craft.users" class="mb-1" v-if="!closedCrafts.includes(craft.id)">
+                                    <div class="w-full p-2 text-white text-xs rounded-lg gap-2 relative h-8 flex items-center justify-between cursor-pointer" @click="createOnDropElementAndSave(user, craft)" :style="{backgroundColor: backgroundColorWithOpacityOld(craft.color )}">
+                                        <div v-if="user.type === 0 || user.type === 1">
+                                            {{ user.first_name }} {{ user.last_name }}
+                                        </div>
+                                        <div v-else>
+                                            {{ user.provider_name }}
+                                        </div>
+
+                                        <div v-if="user.type === 0 && user.is_freelancer || user.type === 1">
+                                            <ToolTipComponent
+                                                icon="IconId"
+                                                icon-size="w-4 h-4"
+                                                tooltip-text="Freelancer*in"
+                                                direction="left"
+                                                classes="text-gray-300"
+                                            />
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </MenuItems>
+            </transition>
+        </Float>
+    </Menu>
+
+</template>
+
+<script setup>
+
+import {Float} from "@headlessui-float/vue";
+import ToolTipComponent from "@/Components/ToolTips/ToolTipComponent.vue";
+import {IconChevronDown, IconChevronUp, IconFilter, IconSearch, IconX} from "@tabler/icons-vue";
+import {MenuButton, MenuItems, Menu} from "@headlessui/vue";
+import Input from "@/Jetstream/Input.vue";
+import {computed, nextTick, ref, watch} from "vue"
+import {useColorHelper} from "@/Composeables/UseColorHelper.js";
+const {backgroundColorWithOpacityOld, TextColorWithDarken} = useColorHelper()
+
+const props = defineProps({
+    craftsWithEntities: {
+        type: Object,
+        required: true,
+    },
+})
+
+
+const openFilter = ref(false)
+const searchFieldUserSearch = ref(null)
+const userSearch = ref('')
+const showIntern = ref(false)
+const showExtern = ref(false)
+const showProvider = ref(false)
+const closedCrafts = ref([])
+const menuOpen = ref(false)
+
+const emit = defineEmits(['createOnDropElementAndSave'])
+
+const openOrCloseFilter = () => {
+    openFilter.value = !openFilter.value
+
+    if(openFilter.value) {
+        nextTick(() => {
+            searchFieldUserSearch.value.focus()
+        })
+    }
+}
+
+
+const craftWithUserFilterByType = computed(() => {
+    return props.craftsWithEntities.map(craft => {
+        return {
+            ...craft,
+            users: craft.users.filter(user => {
+                if (!showIntern.value && !showExtern.value && !showProvider.value) {
+                    return true;
+                }
+                if (showIntern.value && user.type === 0) {
+                    return true;
+                }
+                if (showExtern.value && user.type === 1) {
+                    return true;
+                }
+                return showProvider.value && user.type === 2;
+            })
+        }
+    })
+});
+
+
+const craftWithUserFilteredByName = computed(() => {
+    return craftWithUserFilterByType.value.map(craft => {
+        return {
+            ...craft,
+            users: craft.users.filter(user => {
+                if(user.type === 0 || user.type === 1) {
+                    return user.first_name.toLowerCase().includes(userSearch.value.toLowerCase()) || user.last_name.toLowerCase().includes(userSearch.value.toLowerCase())
+                }
+                return user.provider_name.toLowerCase().includes(userSearch.value.toLowerCase())
+            })
+        }
+    })
+})
+
+const changeCraftVisibility = (id) => {
+    if (closedCrafts.value.includes(id)) {
+        closedCrafts.value.splice(closedCrafts.value.indexOf(id), 1);
+    } else {
+        closedCrafts.value.push(id);
+    }
+}
+
+const createOnDropElementAndSave = (user, craft) => {
+    emit('createOnDropElementAndSave', user, craft)
+}
+
+watch(userSearch, () => {
+    if(userSearch.value.length > 0) {
+        closedCrafts.value = []
+    }
+})
+</script>
+
+<style scoped>
+
+</style>

--- a/resources/js/Pages/Projects/Components/ShiftBookedElementComponent.vue
+++ b/resources/js/Pages/Projects/Components/ShiftBookedElementComponent.vue
@@ -1,0 +1,477 @@
+<template>
+    <SelectUserForShiftMenu :crafts-with-entities="sortedCraftsWithEntities" @create-on-drop-element-and-save="createOnDropElementAndSave">
+        <div class="flex items-center p-1 hover:bg-gray-50/40 rounded cursor-pointer group w-full h-full"  @dragover="onDragOver" @drop="onDrop">
+            <div class="flex gap-1 items-center justify-between w-full h-full">
+                <div class="h-full">
+                    <div class="flex items-center gap-1" v-if="type === 0 || type === 1">
+                        <UserPopoverTooltip :user="user" height="4" width="4" class="flex items-center" />
+                        <span class="text-xs flex items-center gap-1">
+                            {{ user.first_name }} {{ user.last_name }}
+                        <span v-if="user.pivot.craft_abbreviation !== shift.craft.abbreviation && user.pivot.craft_abbreviation !== null" class="text-[8px]">[{{ user.pivot.craft_abbreviation}}]</span>
+                        <span v-if="user.pivot.shift_count > 1" class="text-xs"> 1/{{ user.pivot.shift_count }}</span>
+                    </span>
+                    </div>
+                    <div v-else class="flex items-center gap-1">
+                        <img :src="user.profile_photo_url" class="h-4 w-4 rounded-full block bg-gray-500 object-cover" alt="profile-photo">
+                        <span class="text-xs flex items-center gap-1">
+                             <span class="w-24 truncate">{{ user.provider_name }}</span>
+                        <span v-if="user.pivot.shift_count > 1" class="text-xs"> 1/{{ user.pivot.shift_count }}</span>
+                        <span v-if="user.pivot.craft_abbreviation !== shift.craft.abbreviation && user.pivot.craft_abbreviation !== null" class="text-[8px]">[{{ user.pivot.craft_abbreviation}}]</span>
+                    </span>
+                    </div>
+                </div>
+                <ShiftQualificationIconCollection
+                    :classes="'w-4 h-4'"
+                    class=" block group-hover:hidden"
+                    :icon-name="getShiftQualificationById(user.pivot.shift_qualification_id).icon"/>
+            </div>
+            <div v-if="can('can plan shifts') || hasAdminRole()" class="hidden group-hover:block"
+                 @click="event.is_series ? openDeleteUserModal(user.pivot.id, type) : deleteUserFromShift(user.pivot.id, type)">
+                <span class="flex items-center justify-center">
+                    <span class="rounded-full bg-red-400 p-0.5 h-4 w-4 flex items-center justify-center border border-white shadow-[0px_0px_5px_0px_#fc8181]">
+                        <IconX class="w-2 h-2 text-white" />
+                    </span>
+                </span>
+            </div>
+        </div>
+
+    </SelectUserForShiftMenu>
+
+    <div class="absolute w-full h-full bg-gray-300/10 top-0 left-0 rounded-lg z-50" v-show="isUpdateContainer">
+        <div class="flex items-center justify-center h-full w-full text-xs">
+            <div class="bg-black text-white px-4 py-1 rounded-lg">
+                {{ $t('Updating...')}}
+            </div>
+        </div>
+    </div>
+
+    <ChooseDeleteUserShiftModal
+        v-if="showDeleteUserModal"
+        @close-modal="closeDeleteUserModal"
+        @returnBuffer="deleteUserWithSeriesShiftData"
+    />
+
+    <ChooseUserSeriesShift
+        v-if="showChooseUserSeriesShiftModal"
+        @close-modal="showChooseUserSeriesShiftModal = false"
+        @returnBuffer="setSeriesShiftData"
+    />
+    <MultipleShiftQualificationSlotsAvailable
+        v-if="showMultipleShiftQualificationSlotsAvailableModal"
+        :show="showMultipleShiftQualificationSlotsAvailableModal"
+        :available-shift-qualification-slots="showMultipleShiftQualificationSlotsAvailableModalSlots"
+        :dropped-user="showMultipleShiftQualificationSlotsAvailableModalDroppedUser"
+        @close="closeMultipleShiftQualificationSlotsAvailableModal"
+    />
+</template>
+
+<script setup>
+
+import {IconX} from "@tabler/icons-vue";
+import UserPopoverTooltip from "@/Layouts/Components/UserPopoverTooltip.vue";
+import ShiftQualificationIconCollection from "@/Layouts/Components/ShiftQualificationIconCollection.vue";
+import {usePermission} from "@/Composeables/Permission.js";
+import {router, usePage} from "@inertiajs/vue3";
+import ChooseDeleteUserShiftModal from "@/Pages/Projects/Components/ChooseDeleteUserShiftModal.vue";
+import {computed, nextTick, ref} from "vue";
+import ChooseUserSeriesShift from "@/Pages/Projects/Components/ChooseUserSeriesShift.vue";
+import MultipleShiftQualificationSlotsAvailable
+    from "@/Pages/Projects/Components/MultipleShiftQualificationSlotsAvailable.vue";
+import SelectUserForShiftMenu from "@/Pages/Projects/Components/SelectUserForShiftMenu.vue";
+const { can, canAny, hasAdminRole } = usePermission(usePage().props)
+
+import {useTranslation} from "@/Composeables/Translation.js";
+const $t = useTranslation()
+
+const props = defineProps({
+    user: {
+        type: Object,
+        required: true
+    },
+    type: {
+        type: Number,
+        required: true
+    },
+    event: {
+        type: Object,
+        required: true
+    },
+    shift: {
+        type: Object,
+        required: true
+    },
+    shiftQualifications: {
+        type: Object,
+        required: true
+    },
+    craftWithEntities: {
+        type: Object,
+        required: true
+    },
+    craftId: {
+        type: Number,
+        required: true
+    },
+    shiftId: {
+        type: Number,
+        required: true
+    },
+    shiftUserIds: {
+        type: Object,
+        required: true
+    },
+    allShiftQualificationDropElements: {
+        type: Object,
+        required: true
+    },
+    eventIsSeries: {
+        type: Boolean,
+        required: true
+    },
+    crafts: {
+        type: Object,
+        required: true
+    },
+})
+
+
+const showDeleteUserModal = ref(false);
+const usersPivotIdToDelete = ref(null);
+const userTypeToDelete = ref(null);
+const droppedUser = ref({});
+const isUpdateContainer = ref(false);
+
+const showChooseUserSeriesShiftModal = ref(false);
+const seriesShiftData = ref(null);
+const showMultipleShiftQualificationSlotsAvailableModal = ref(false);
+const showMultipleShiftQualificationSlotsAvailableModalSlots = ref(null);
+const showMultipleShiftQualificationSlotsAvailableModalDroppedUser = ref(null);
+
+const emits = defineEmits(['dropFeedback']);
+
+const sortedCraftsWithEntities = computed(() => {
+    return props.craftWithEntities.map((craft) => {
+        let users = craft.users.map((user) => {
+            return {
+                ...user,
+                type: 0
+            }
+        });
+
+        let freelancers = craft.freelancers.map((freelancer) => {
+            return {
+                ...freelancer,
+                type: 1
+            }
+        });
+
+        let serviceProviders = craft.service_providers.map((serviceProvider) => {
+            return {
+                ...serviceProvider,
+                type: 2
+            }
+        });
+
+        return {
+            ...craft,
+            users: users.concat(freelancers).concat(serviceProviders)
+        }
+    });
+})
+
+const onDragOver = (event) => {
+    event.preventDefault();
+}
+
+const onDrop = (event) =>  {
+    event.preventDefault();
+
+    droppedUser.value = JSON.parse(event.dataTransfer.getData('application/json'));
+
+    saveUser();
+}
+
+const getShiftQualificationById = (id) => {
+    return props.shiftQualifications.find((shiftQualification) => shiftQualification.id === id);
+}
+
+const closeDeleteUserModal = () => {
+    showDeleteUserModal.value = false;
+}
+
+const deleteUserWithSeriesShiftData = (removeFromSingleShift) => {
+   closeDeleteUserModal();
+    deleteUserFromShift(usersPivotIdToDelete.value, userTypeToDelete.value, removeFromSingleShift);
+
+    usersPivotIdToDelete.value = null;
+    userTypeToDelete.value = null;
+}
+
+const openDeleteUserModal = (usersPivotId, userType) => {
+    showDeleteUserModal.value = true;
+    usersPivotIdToDelete.value = usersPivotId;
+    userTypeToDelete.value = userType;
+}
+
+const deleteUserFromShift = (usersPivotId, userType, removeFromSingleShift = true, preserveState = false) => {
+    console.log('deleteUserFromShift');
+    router.delete(
+        route(
+            'shift.removeUserByType',
+            {
+                usersPivotId: usersPivotId,
+                userType: userType,
+                isShiftTab: true
+            }
+        ),
+        {
+            data: {
+                removeFromSingleShift: removeFromSingleShift
+            },
+            preserveScroll: true,
+            preserveState: preserveState,
+            onSuccess: () => {
+                isUpdateContainer.value = false;
+            }
+        }
+    );
+}
+
+
+const setSeriesShiftData = (seriesShiftData) => {
+    showChooseUserSeriesShiftModal.value = false;
+    seriesShiftData.value = seriesShiftData;
+    saveUser();
+}
+const saveUser = () => {
+
+    if(!droppedUser.value.craft_universally_applicable) {
+        if (droppedUserCannotBeAssignedToCraft(droppedUser.value)) {
+            dropFeedbackUserCannotBeAssignedToCraft(droppedUser.value.type);
+            isUpdateContainer.value = false;
+            return;
+        }
+    }
+
+    if (droppedUserAlreadyWorksOnShift(droppedUser.value)) {
+        dropFeedbackUserAlreadyWorksOnShift(droppedUser.value.type);
+        isUpdateContainer.value = false;
+        return;
+    }
+
+    if (droppedUserHasNoQualifications(droppedUser.value)) {
+        dropFeedbackUserHasNoQualifications(droppedUser.value.type);
+        isUpdateContainer.value = false;
+        return;
+    }
+
+    if (droppedUser.value.shift_qualifications.length === 1) {
+        let availableSlot = props.allShiftQualificationDropElements.find(
+            (dropElement) => dropElement.shift_qualification_id === droppedUser.value.shift_qualifications[0].id
+        );
+
+        if (typeof availableSlot === 'undefined') {
+            dropFeedbackNoSlotsForQualification(droppedUser.value.type);
+            isUpdateContainer.value = false;
+            return;
+        }
+
+        assignUser(droppedUser.value, availableSlot.shift_qualification_id);
+    } else {
+        let availableShiftQualificationSlots = [];
+
+        droppedUser.value.shift_qualifications.forEach((userShiftQualification) => {
+            props.allShiftQualificationDropElements.forEach((shiftQualificationDropElement) => {
+                if (userShiftQualification.id === shiftQualificationDropElement.shift_qualification_id) {
+                    availableShiftQualificationSlots.push(userShiftQualification);
+                }
+            })
+        });
+
+        if (availableShiftQualificationSlots.length === 0) {
+            dropFeedbackNoSlotsForQualification(droppedUser.value.type);
+            isUpdateContainer.value = false;
+            return;
+        }
+
+        if (availableShiftQualificationSlots.length === 1) {
+            assignUser(
+                droppedUser.value,
+                availableShiftQualificationSlots[0].id
+            );
+            return;
+        }
+
+        //show select modal by availableSlots
+        openMultipleShiftQualificationSlotsAvailableModal(
+            droppedUser.value,
+            availableShiftQualificationSlots
+        );
+    }
+}
+const droppedUserAlreadyWorksOnShift = (droppedUser) => {
+    if (droppedUser.type === 0) {
+        if (props.shiftUserIds.userIds.includes(droppedUser.id)) {
+            return true;
+        }
+    }
+
+    if (droppedUser.type === 1) {
+        if (props.shiftUserIds.freelancerIds.includes(droppedUser.id)) {
+            return true;
+        }
+    }
+
+    if (droppedUser.type === 2) {
+        if (props.shiftUserIds.providerIds.includes(droppedUser.id)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+const dropFeedbackUserAlreadyWorksOnShift = (userType) => {
+    let userDescription = '';
+
+    switch (userType) {
+        case 0:
+            userDescription = $t('Employee');
+            break;
+        case 1:
+            userDescription = $t('Freelancer');
+            break;
+        case 2:
+            userDescription = $t('ServiceProvider');
+            break;
+    }
+
+    emits(
+        'dropFeedback',
+        $t('{0} already assigned to a shift.', [userDescription])
+    );
+}
+const droppedUserCannotBeAssignedToCraft = (droppedUser) => {
+    return droppedUser.craft_ids && !droppedUser.craft_ids.includes(props.craftId);
+}
+const dropFeedbackUserCannotBeAssignedToCraft = (userType) => {
+    let userDescription = '';
+
+    switch (userType) {
+        case 0:
+            userDescription = $t('Employee');
+            break;
+        case 1:
+            userDescription = $t('Freelancer');
+            break;
+        case 2:
+            userDescription = $t('ServiceProvider');
+            break;
+    }
+
+    emits(
+        'dropFeedback',
+        $t('{0} cannot be assigned to shifts of this craft.', [userDescription])
+    );
+}
+const droppedUserHasNoQualifications = (droppedUser) => {
+    return droppedUser.shift_qualifications.length === 0;
+}
+const dropFeedbackUserHasNoQualifications = (userType) => {
+    let userDescription = '';
+
+    switch (userType) {
+        case 0:
+            userDescription = $t('Employee');
+            break;
+        case 1:
+            userDescription = $t('Freelancer');
+            break;
+        case 2:
+            userDescription = $t('ServiceProvider');
+            break;
+    }
+
+    emits(
+        'dropFeedback',
+        $t('{0} has no qualifications and therefore cannot be assigned.', [userDescription])
+    );
+}
+const dropFeedbackNoSlotsForQualification = (userType) => {
+    let userDescription = '';
+
+    switch (userType) {
+        case 0:
+            userDescription = $t('this employee');
+            break;
+        case 1:
+            userDescription = $t('this freelancer');
+            break;
+        case 2:
+            userDescription = $t('this service provider');
+            break;
+    }
+
+    emits(
+        'dropFeedback',
+        $t(
+            'There is no position that can be filled by {0} with the available qualifications.',
+            [userDescription]
+        )
+    );
+}
+const openMultipleShiftQualificationSlotsAvailableModal = (droppedUser, availableShiftQualificationSlots) => {
+    showMultipleShiftQualificationSlotsAvailableModalDroppedUser.value = droppedUser;
+    showMultipleShiftQualificationSlotsAvailableModalSlots.value = availableShiftQualificationSlots;
+    showMultipleShiftQualificationSlotsAvailableModal.value = true;
+}
+const closeMultipleShiftQualificationSlotsAvailableModal = (droppedUser, selectedShiftQualificationId, closeOnButton) => {
+    showMultipleShiftQualificationSlotsAvailableModal.value = false;
+    showMultipleShiftQualificationSlotsAvailableModalSlots.value = null;
+    showMultipleShiftQualificationSlotsAvailableModalDroppedUser.value = null;
+
+    if (droppedUser && selectedShiftQualificationId) {
+        assignUser(droppedUser, selectedShiftQualificationId);
+    }
+
+    if(closeOnButton) {
+        isUpdateContainer.value = false;
+    }
+}
+const assignUser = (droppedUser, shiftQualificationId) => {
+    //console.log('assignUser', droppedUser, shiftQualificationId);
+    router.post(
+        route('shift.assignUserByType', {shift: props.shiftId}),
+        {
+            userId: droppedUser.id,
+            userType: droppedUser.type,
+            shiftQualificationId: shiftQualificationId,
+            seriesShiftData: seriesShiftData.value,
+            isShiftTab: true,
+            craft_abbreviation: droppedUser.craft_abbreviation
+        },
+        {
+            preserveScroll: true,
+            onSuccess: () => {
+                deleteUserFromShift(props.user.pivot.id, props.type, true, false);
+            }
+        },
+    )
+}
+const createOnDropElementAndSave = (user, craft) => {
+    isUpdateContainer.value = true;
+    droppedUser.value = {
+        id: user.id,
+        type: user.type,
+        craft_ids: user.assigned_craft_ids,
+        shift_qualifications: user.shift_qualifications ?? [],
+        craft_universally_applicable: craft?.universally_applicable ?? false,
+        craft_abbreviation: craft.abbreviation ?? '',
+    };
+
+    saveUser();
+}
+</script>
+
+<style scoped>
+
+</style>

--- a/resources/js/Pages/Projects/Components/ShiftBookedElementComponent.vue
+++ b/resources/js/Pages/Projects/Components/ShiftBookedElementComponent.vue
@@ -214,7 +214,6 @@ const openDeleteUserModal = (usersPivotId, userType) => {
 }
 
 const deleteUserFromShift = (usersPivotId, userType, removeFromSingleShift = true, preserveState = false) => {
-    console.log('deleteUserFromShift');
     router.delete(
         route(
             'shift.removeUserByType',
@@ -438,7 +437,6 @@ const closeMultipleShiftQualificationSlotsAvailableModal = (droppedUser, selecte
     }
 }
 const assignUser = (droppedUser, shiftQualificationId) => {
-    //console.log('assignUser', droppedUser, shiftQualificationId);
     router.post(
         route('shift.assignUserByType', {shift: props.shiftId}),
         {

--- a/resources/js/Pages/Projects/Components/ShiftsQualificationsDropElement.vue
+++ b/resources/js/Pages/Projects/Components/ShiftsQualificationsDropElement.vue
@@ -1,16 +1,14 @@
 <template>
-    <div class="flex items-center pl-1 py-1 hover:bg-gray-50/40 rounded cursor-pointer w-full"
-         @dragover="onDragOver"
-         @drop="onDrop"
-         @click="openReplaceUserModal"
-    >
-        <div class="flex items-center justify-between w-full">
-            <div class="flex items-center gap-2">
-                <span class="h-4 w-4 rounded-full block bg-gray-500"></span>
-                <span class="text-xs">{{ $t('Unoccupied') }}</span>
+    <div class="flex items-center pl-1 py-1 hover:bg-gray-50/40 rounded cursor-pointer w-full h-6" @dragover="onDragOver" @drop="onDrop">
+        <SelectUserForShiftMenu :crafts-with-entities="craftsWithAllEntities" @create-on-drop-element-and-save="createOnDropElementAndSave">
+            <div class="flex items-center justify-between w-full">
+                <div class="flex items-center gap-2">
+                    <span class="h-4 w-4 rounded-full block bg-gray-500"></span>
+                    <span class="text-xs">{{ $t('Unoccupied') }}</span>
+                </div>
+                <ShiftQualificationIconCollection :classes="'w-4 h-4'" class="w-5 h-5" :icon-name="this.shiftQualification.icon"/>
             </div>
-            <ShiftQualificationIconCollection :classes="'w-4 h-4'" class="w-5 h-5" :icon-name="this.shiftQualification.icon"/>
-        </div>
+        </SelectUserForShiftMenu>
     </div>
     <ChooseUserSeriesShift
         v-if="this.showChooseUserSeriesShiftModal"
@@ -27,19 +25,35 @@
 </template>
 
 <script>
-import {defineComponent} from 'vue';
+import {defineComponent, nextTick} from 'vue';
 import ShiftQualificationIconCollection from "@/Layouts/Components/ShiftQualificationIconCollection.vue";
 import ChooseUserSeriesShift from "@/Pages/Projects/Components/ChooseUserSeriesShift.vue";
 import MultipleShiftQualificationSlotsAvailable
     from "@/Pages/Projects/Components/MultipleShiftQualificationSlotsAvailable.vue";
 import {router} from "@inertiajs/vue3";
+import SelectUserForShiftMenu from "@/Pages/Projects/Components/SelectUserForShiftMenu.vue";
+import ToolTipComponent from "@/Components/ToolTips/ToolTipComponent.vue";
+import {IconChevronDown, IconChevronUp, IconDotsVertical, IconFilter, IconSearch, IconX} from "@tabler/icons-vue";
+import {Float} from "@headlessui-float/vue";
+import {Menu, MenuButton, MenuItems} from "@headlessui/vue";
+import DragElement from "@/Pages/Projects/Components/DragElement.vue";
+import ColorHelper from "@/Mixins/ColorHelper.vue";
+import CraftFilter from "@/Components/Filter/CraftFilter.vue";
+import Input from "@/Jetstream/Input.vue";
 
 export default defineComponent({
     name: 'ShiftsQualificationsDropElement',
+    mixins: [ColorHelper],
     components: {
+        IconFilter, Input, IconSearch, IconChevronUp, CraftFilter, IconX,
+        DragElement, IconChevronDown,
+        Float,
+        IconDotsVertical, ToolTipComponent,
+        SelectUserForShiftMenu,
         MultipleShiftQualificationSlotsAvailable,
         ShiftQualificationIconCollection,
-        ChooseUserSeriesShift
+        ChooseUserSeriesShift,
+        MenuButton, MenuItems, Menu
     },
     props: [
         'craftId',
@@ -47,7 +61,9 @@ export default defineComponent({
         'shiftUserIds',
         'eventIsSeries',
         'shiftQualification',
-        'allShiftQualificationDropElements'
+        'allShiftQualificationDropElements',
+        'shiftCraftsWithUsers',
+        'crafts'
     ],
     emits: ['dropFeedback'],
     data(){
@@ -57,13 +73,49 @@ export default defineComponent({
             droppedUser: null,
             showMultipleShiftQualificationSlotsAvailableModal: false,
             showMultipleShiftQualificationSlotsAvailableModalSlots: null,
-            showMultipleShiftQualificationSlotsAvailableModalDroppedUser: null
+            showMultipleShiftQualificationSlotsAvailableModalDroppedUser: null,
+            showSelectUserMenu: false,
+            openFilter: false,
+            showIntern: false,
+            showExtern: false,
+            showProvider: false,
+            userSearch: '',
+            isMenuOpen: false
         }
     },
-    methods: {
-        openReplaceUserModal() {
-            console.log('openReplaceUserModal');
+    computed: {
+        craftsWithAllEntities() {
+            // return craft with all entities also users, freelancers, service providers in one array named entities
+            return this.shiftCraftsWithUsers.map((craft) => {
+                let users = craft.users.map((user) => {
+                    return {
+                        ...user,
+                        type: 0
+                    }
+                });
+
+                let freelancers = craft.freelancers.map((freelancer) => {
+                    return {
+                        ...freelancer,
+                        type: 1
+                    }
+                });
+
+                let serviceProviders = craft.service_providers.map((serviceProvider) => {
+                    return {
+                        ...serviceProvider,
+                        type: 2
+                    }
+                });
+
+                return {
+                    ...craft,
+                    users: users.concat(freelancers).concat(serviceProviders)
+                }
+            });
         },
+    },
+    methods: {
         onDragOver(event) {
             event.preventDefault();
         },
@@ -282,6 +334,25 @@ export default defineComponent({
                     preserveScroll: true
                 }
             )
+        },
+        createOnDropElementAndSave(user, craft) {
+
+            this.droppedUser = {
+                id: user.id,
+                type: user.type,
+                craft_ids: user.assigned_craft_ids,
+                shift_qualifications: user.shift_qualifications ?? [],
+                craft_universally_applicable: craft?.universally_applicable ?? false,
+                craft_abbreviation: craft.abbreviation ?? '',
+            };
+            this.isMenuOpen = false;
+
+            // click on page to close menu
+            nextTick(() => {
+                document.addEventListener('click', this.closeMenu);
+            });
+
+            this.saveUser();
         }
    }
 });

--- a/resources/js/Pages/Projects/Components/ShiftsQualificationsDropElement.vue
+++ b/resources/js/Pages/Projects/Components/ShiftsQualificationsDropElement.vue
@@ -1,11 +1,15 @@
 <template>
-    <div class="flex items-center gap-2 p-1 hover:bg-gray-50/40 rounded cursor-pointer"
+    <div class="flex items-center pl-1 py-1 hover:bg-gray-50/40 rounded cursor-pointer w-full"
          @dragover="onDragOver"
-         @drop="onDrop">
-        <div class="flex items-center">
-            <span class="h-4 w-4 rounded-full block bg-gray-500"></span>
-            <span class="ml-2 text-xs">{{ $t('Unoccupied') }}</span>
-            <ShiftQualificationIconCollection :classes="'w-4 h-4'" class="ml-2 w-5 h-5" :icon-name="this.shiftQualification.icon"/>
+         @drop="onDrop"
+         @click="openReplaceUserModal"
+    >
+        <div class="flex items-center justify-between w-full">
+            <div class="flex items-center gap-2">
+                <span class="h-4 w-4 rounded-full block bg-gray-500"></span>
+                <span class="text-xs">{{ $t('Unoccupied') }}</span>
+            </div>
+            <ShiftQualificationIconCollection :classes="'w-4 h-4'" class="w-5 h-5" :icon-name="this.shiftQualification.icon"/>
         </div>
     </div>
     <ChooseUserSeriesShift
@@ -57,6 +61,9 @@ export default defineComponent({
         }
     },
     methods: {
+        openReplaceUserModal() {
+            console.log('openReplaceUserModal');
+        },
         onDragOver(event) {
             event.preventDefault();
         },

--- a/resources/js/Pages/Projects/Components/SingleShift.vue
+++ b/resources/js/Pages/Projects/Components/SingleShift.vue
@@ -1,5 +1,5 @@
 <template>
-    <div :class="[highlight, 'w-[175px] flex flex-col relative']" :id="'shift-container-' + event.id + '-' + shift.id">
+    <div :class="[highlight, 'w-[185px] flex flex-col relative']" :id="'shift-container-' + event.id + '-' + shift.id">
         <div class="h-[36px] rounded-t-lg flex items-center justify-between px-4 text-white text-xs relative"
              :class="[
                  this.computedMaxWorkerCount === this.computedUsedWorkerCount ?
@@ -67,14 +67,16 @@
             </p>
             <ShiftNoteComponent :shift="shift" />
             <div v-for="user in shift.users">
-                <div class="flex items-center justify-between p-1 hover:bg-gray-50/40 rounded cursor-pointer group">
-                    <div class="flex gap-2 items-center">
-                        <UserPopoverTooltip :user="user" height="4" width="4" class="flex items-center" />
-                        <span class="text-xs">
-                            {{ user.full_name }}
-                            <span v-if="user.pivot.craft_abbreviation !== shift.craft.abbreviation && user.pivot.craft_abbreviation !== null">[{{ user.pivot.craft_abbreviation}}]</span>
-                        </span>
-                        <span v-if="user.pivot.shift_count > 1" class="text-xs"> 1/{{ user.pivot.shift_count }}</span>
+                <div class="flex items-center p-1 hover:bg-gray-50/40 rounded cursor-pointer group w-full h-full">
+                    <div class="flex gap-2 items-center justify-between w-full h-full">
+                        <div class="flex gap-2 items-center h-full">
+                            <UserPopoverTooltip :user="user" height="4" width="4" class="flex items-center" />
+                            <span class="text-xs flex items-center">
+                                {{ user.full_name }}
+                                <span v-if="user.pivot.craft_abbreviation !== shift.craft.abbreviation && user.pivot.craft_abbreviation !== null">[{{ user.pivot.craft_abbreviation}}]</span>
+                            </span>
+                            <span v-if="user.pivot.shift_count > 1" class="text-xs"> 1/{{ user.pivot.shift_count }}</span>
+                        </div>
                         <ShiftQualificationIconCollection
                             :classes="'w-4 h-4'"
                             :icon-name="this.getShiftQualificationById(user.pivot.shift_qualification_id).icon"/>
@@ -164,6 +166,9 @@
             </div>
         </div>
     </div>
+    <pre>
+        {{ getUsersInCraftOfShiftAndUsersFromCraftsWhereUniversalApplicable }}
+    </pre>
     <AddShiftModal v-if="openEditShiftModal"
                    :shift="shift"
                    :event="event"
@@ -262,6 +267,12 @@ export default defineComponent({
         }, 5000);
     },
     computed: {
+        getUsersInCraftOfShiftAndUsersFromCraftsWhereUniversalApplicable() {
+            // return craft from shift and return crafts where universally_applicable is true
+            return this.crafts.filter(
+                (craft) => craft.id === this.shift.craft.id || craft.universally_applicable
+            );
+        },
         computedMaxWorkerCount() {
             let maxWorkerCount = 0;
 

--- a/resources/js/Pages/Projects/Components/SingleShift.vue
+++ b/resources/js/Pages/Projects/Components/SingleShift.vue
@@ -1,5 +1,5 @@
 <template>
-    <div :class="[highlight, 'w-[185px] flex flex-col relative']" :id="'shift-container-' + event.id + '-' + shift.id">
+    <div :class="[highlight, 'w-[190px] flex flex-col relative']" :id="'shift-container-' + event.id + '-' + shift.id">
         <div class="h-[36px] rounded-t-lg flex items-center justify-between px-4 text-white text-xs relative"
              :class="[
                  this.computedMaxWorkerCount === this.computedUsedWorkerCount ?
@@ -55,7 +55,7 @@
                 </div>
             </div>
         </div>
-        <div class="mt-1 rounded-b-lg bg-gray-200 px-1 py-2 overflow-y-scroll h-full">
+        <div class="mt-1 rounded-b-lg bg-gray-200 px-1 py-2 overflow-y-scroll h-full w-full">
             <p class="text-xs mb-1">
                 <span v-if="shift.start_date && shift.end_date && shift.start_date !== shift.end_date">
                     {{ shift.formatted_dates.start }} {{ shift.start }} - {{ shift.formatted_dates.end }} {{ shift.end }}
@@ -67,87 +67,55 @@
             </p>
             <ShiftNoteComponent :shift="shift" />
             <div v-for="user in shift.users">
-                <div class="flex items-center p-1 hover:bg-gray-50/40 rounded cursor-pointer group w-full h-full">
-                    <div class="flex gap-2 items-center justify-between w-full h-full">
-                        <div class="flex gap-2 items-center h-full">
-                            <UserPopoverTooltip :user="user" height="4" width="4" class="flex items-center" />
-                            <span class="text-xs flex items-center">
-                                {{ user.full_name }}
-                                <span v-if="user.pivot.craft_abbreviation !== shift.craft.abbreviation && user.pivot.craft_abbreviation !== null">[{{ user.pivot.craft_abbreviation}}]</span>
-                            </span>
-                            <span v-if="user.pivot.shift_count > 1" class="text-xs"> 1/{{ user.pivot.shift_count }}</span>
-                        </div>
-                        <ShiftQualificationIconCollection
-                            :classes="'w-4 h-4'"
-                            :icon-name="this.getShiftQualificationById(user.pivot.shift_qualification_id).icon"/>
-                    </div>
-                    <div v-if="this.$can('can plan shifts') || this.hasAdminRole()" class="hidden group-hover:block"
-                         @click="
-                            this.event.is_series ?
-                                openDeleteUserModal(user.pivot.id, 0) :
-                                deleteUserFromShift(user.pivot.id, 0)
-                         ">
-                        <span class="flex items-center justify-center">
-                            <span class="rounded-full bg-red-400 p-0.5 h-4 w-4 flex items-center justify-center border border-white shadow-[0px_0px_5px_0px_#fc8181]">
-                                <IconX class="w-2 h-2 text-white" />
-                            </span>
-                        </span>
-                    </div>
-                </div>
+                <ShiftBookedElementComponent
+                    :user="user"
+                    :type="0"
+                    :shift="shift"
+                    :event="event"
+                    :shift-qualifications="shiftQualifications"
+                    :craft-id="this.shift.craft.id"
+                    :shift-id="shift.id"
+                    :shift-user-ids="shiftUserIds"
+                    :event-is-series="event.is_series"
+                    :all-shift-qualification-drop-elements="this.computedShiftQualificationDropElements"
+                    :crafts="crafts"
+                    @dropFeedback="dropFeedback"
+                    :craft-with-entities="getUsersInCraftOfShiftAndUsersFromCraftsWhereUniversalApplicable"
+                />
             </div>
             <div v-for="freelancer in shift.freelancer">
-                <div class="flex items-center justify-between p-1 hover:bg-gray-50/40 rounded cursor-pointer group">
-                    <div class="flex gap-2 items-center">
-                        <UserPopoverTooltip :user="freelancer" height="4" width="4" class="flex items-center" />
-                        <span class="text-xs">
-                            {{ freelancer.name }}
-                            <span v-if="freelancer.pivot.craft_abbreviation !== shift.craft.abbreviation && freelancer.pivot.craft_abbreviation !== null">[{{ freelancer.pivot.craft_abbreviation}}]</span>
-                        </span>
-                        <span v-if="freelancer.pivot.shift_count > 1" class="text-xs"> 1/{{ freelancer.pivot.shift_count }}</span>
-                        <ShiftQualificationIconCollection
-                            class="w-5 h-5"  :classes="'w-4 h-4'"
-                            :icon-name="this.getShiftQualificationById(freelancer.pivot.shift_qualification_id).icon"/>
-                    </div>
-                    <div v-if="this.$can('can plan shifts') || this.hasAdminRole()" class="hidden group-hover:block"
-                         @click="
-                            this.event.is_series ?
-                                openDeleteUserModal(freelancer.pivot.id, 1) :
-                                deleteUserFromShift(freelancer.pivot.id, 1)
-                         ">
-                        <span class="flex items-center justify-center">
-                            <span class="rounded-full bg-red-400 p-0.5 h-4 w-4 flex items-center justify-center border border-white shadow-[0px_0px_5px_0px_#fc8181]">
-                                <IconX class="w-2 h-2 text-white" />
-                            </span>
-                        </span>
-                    </div>
-                </div>
+                <ShiftBookedElementComponent
+                    :user="freelancer"
+                    :type="1"
+                    :shift="shift"
+                    :event="event"
+                    :shift-qualifications="shiftQualifications"
+                    :craft-id="this.shift.craft.id"
+                    :shift-id="shift.id"
+                    :shift-user-ids="shiftUserIds"
+                    :event-is-series="event.is_series"
+                    :all-shift-qualification-drop-elements="this.computedShiftQualificationDropElements"
+                    :crafts="crafts"
+                    @dropFeedback="dropFeedback"
+                    :craft-with-entities="getUsersInCraftOfShiftAndUsersFromCraftsWhereUniversalApplicable"
+                />
             </div>
             <div v-for="serviceProvider in shift.service_provider">
-                <div class="flex items-center justify-between p-1 hover:bg-gray-50/40 rounded cursor-pointer group">
-                    <div class="flex gap-2 items-center">
-                        <img :src="serviceProvider.profile_photo_url" class="h-4 w-4 rounded-full block bg-gray-500 object-cover" alt="profile-photo">
-                        <span class="text-xs">
-                            {{ serviceProvider.name }}
-                            <span v-if="serviceProvider.pivot.craft_abbreviation !== shift.craft.abbreviation && serviceProvider.pivot.craft_abbreviation !== null">[{{ serviceProvider.pivot.craft_abbreviation}}]</span>
-                        </span>
-                        <span v-if="serviceProvider.pivot.shift_count > 1" class="text-xs">  1/{{ serviceProvider.pivot.shift_count }} </span>
-                        <ShiftQualificationIconCollection
-                            class="w-5 h-5"  :classes="'w-4 h-4'"
-                            :icon-name="this.getShiftQualificationById(serviceProvider.pivot.shift_qualification_id).icon"/>
-                    </div>
-                    <div v-if="this.$can('can plan shifts') || this.hasAdminRole()" class="hidden group-hover:block"
-                         @click="
-                            this.event.is_series ?
-                                openDeleteUserModal(serviceProvider.pivot.id, 2) :
-                                deleteUserFromShift(serviceProvider.pivot.id, 2)
-                         ">
-                        <span class="flex items-center justify-center">
-                            <span class="rounded-full bg-red-400 p-0.5 h-4 w-4 flex items-center justify-center border border-white shadow-[0px_0px_5px_0px_#fc8181]">
-                                <IconX class="w-2 h-2 text-white" />
-                            </span>
-                        </span>
-                    </div>
-                </div>
+                <ShiftBookedElementComponent
+                    :user="serviceProvider"
+                    :type="2"
+                    :shift="shift"
+                    :event="event"
+                    :shift-qualifications="shiftQualifications"
+                    :craft-id="this.shift.craft.id"
+                    :shift-id="shift.id"
+                    :shift-user-ids="shiftUserIds"
+                    :event-is-series="event.is_series"
+                    :all-shift-qualification-drop-elements="this.computedShiftQualificationDropElements"
+                    :crafts="crafts"
+                    @dropFeedback="dropFeedback"
+                    :craft-with-entities="getUsersInCraftOfShiftAndUsersFromCraftsWhereUniversalApplicable"
+                />
             </div>
             <div v-for="dropElement in this.computedShiftQualificationDropElements">
                 <ShiftsQualificationsDropElement
@@ -158,6 +126,8 @@
                     :event-is-series="event.is_series"
                     :shift-qualification="this.getShiftQualificationById(dropElement.shift_qualification_id)"
                     :all-shift-qualification-drop-elements="this.computedShiftQualificationDropElements"
+                    :shift-crafts-with-users="getUsersInCraftOfShiftAndUsersFromCraftsWhereUniversalApplicable"
+                    :crafts="crafts"
                     @dropFeedback="dropFeedback"
                 />
             </div>
@@ -165,10 +135,9 @@
                 <component is="IconCirclePlus" @click="showAddShiftQualificationModal = true" class="h-5 w-5 xsLight cursor-pointer hover:text-artwork-buttons-hover transition-colors duration-300 ease-in-out" stroke-width="1.5" />
             </div>
         </div>
+
+
     </div>
-    <pre>
-        {{ getUsersInCraftOfShiftAndUsersFromCraftsWhereUniversalApplicable }}
-    </pre>
     <AddShiftModal v-if="openEditShiftModal"
                    :shift="shift"
                    :event="event"
@@ -179,10 +148,7 @@
                    :shift-qualifications="shiftQualifications"
                    :shift-time-presets="shiftTimePresets"
     />
-    <ChooseDeleteUserShiftModal v-if="showDeleteUserModal"
-                                @close-modal="this.closeDeleteUserModal"
-                                @returnBuffer="deleteUserWithSeriesShiftData"
-    />
+
     <AddShiftQualificationToShiftModel
         v-if="showAddShiftQualificationModal"
         @close="showAddShiftQualificationModal = false"
@@ -209,10 +175,12 @@ import UserPopoverTooltip from "@/Layouts/Components/UserPopoverTooltip.vue";
 import ShiftNoteComponent from "@/Layouts/Components/ShiftNoteComponent.vue";
 import Permissions from "@/Mixins/Permissions.vue";
 import AddShiftQualificationToShiftModel from "@/Pages/Projects/Components/AddShiftQualificationToShiftModel.vue";
+import ShiftBookedElementComponent from "@/Pages/Projects/Components/ShiftBookedElementComponent.vue";
 
 export default defineComponent({
     name: "SingleShift",
     components: {
+        ShiftBookedElementComponent,
         AddShiftQualificationToShiftModel,
         ShiftNoteComponent,
         UserPopoverTooltip,
@@ -388,39 +356,7 @@ export default defineComponent({
         editShift() {
             this.openEditShiftModal = true;
         },
-        openDeleteUserModal(usersPivotId, userType) {
-            this.showDeleteUserModal = true;
-            this.usersPivotIdToDelete = usersPivotId;
-            this.userTypeToDelete = userType;
-        },
-        closeDeleteUserModal() {
-            this.showDeleteUserModal = false;
-        },
-        deleteUserWithSeriesShiftData(removeFromSingleShift) {
-            this.closeDeleteUserModal();
-            this.deleteUserFromShift(this.usersPivotIdToDelete, this.userTypeToDelete, removeFromSingleShift);
 
-            this.usersPivotIdToDelete = null;
-            this.userTypeToDelete = null;
-        },
-        deleteUserFromShift(usersPivotId, userType, removeFromSingleShift = true) {
-            router.delete(
-                route(
-                    'shift.removeUserByType',
-                    {
-                        usersPivotId: usersPivotId,
-                        userType: userType,
-                        isShiftTab: true
-                    }
-                ),
-                {
-                    data: {
-                        removeFromSingleShift: removeFromSingleShift
-                    },
-                    preserveScroll: true
-                }
-            );
-        },
     },
 })
 </script>

--- a/resources/js/Pages/Projects/Tab/Components/ShiftTab.vue
+++ b/resources/js/Pages/Projects/Tab/Components/ShiftTab.vue
@@ -124,17 +124,6 @@
                                         {{ $t('Service provider') }}
                                     </div>
                                 </div>
-                                <div class="flex w-full mb-3" v-for="craft in crafts" :key="craft.id">
-                                    <input type="checkbox"
-                                           class="input-checklist-dark"
-                                           v-model="activeCraftFilters"
-                                           :id="'craft-' + craft.id"
-                                           :value="craft.id"
-                                    />
-                                    <div class="xsLight my-auto ml-2">
-                                        {{craft.name}}
-                                    </div>
-                                </div>
                                 <div>
                                     <div>
                                         <label for="account-number" class="block text-xs font-medium leading-6 text-white">

--- a/resources/js/Pages/Projects/Tab/Components/ShiftTab.vue
+++ b/resources/js/Pages/Projects/Tab/Components/ShiftTab.vue
@@ -66,7 +66,7 @@
                     leave-active-class="transition ease-in duration-75"
                     leave-from-class="transform opacity-100 scale-100"
                     leave-to-class="transform opacity-0 scale-95">
-                    <div class="z-50 origin-top-right absolute right-10 px-4 py-2 w-80 shadow-lg bg-primary ring-1 ring-black ring-opacity-5 focus:outline-none"
+                    <div class="z-50 origin-top-right absolute rounded-lg right-10 px-4 py-2 w-80 shadow-xl bg-primary ring-1 ring-black ring-opacity-5 focus:outline-none"
                         v-show="userWindow" ref="containerRef">
                         <div class="flex items-center justify-between">
                             <div class="flex gap-4 items-center" @click="openFilter = !openFilter">
@@ -85,7 +85,7 @@
                                 <Switch @click="toggleCompactMode"
                                         :class="[this.$page.props.user.compact_mode ?
                                         'bg-artwork-buttons-create' :
-                                        'bg-gray-300',
+                                        'bg-darkGrayBg',
                                         'relative inline-flex flex-shrink-0 h-3 w-6 border-2 border-transparent rounded-full cursor-pointer transition-colors ease-in-out duration-200 focus:outline-none']">
                                     <span aria-hidden="true"
                                           :class="[this.$page.props.user.compact_mode ? 'translate-x-3' : 'translate-x-0', 'pointer-events-none inline-block h-2 w-2 rounded-full bg-white shadow transform ring-0 transition ease-in-out duration-200']"/>
@@ -103,7 +103,7 @@
                                 <div class="flex w-full mb-3">
                                     <input v-model="showIntern"
                                            type="checkbox"
-                                           class="cursor-pointer h-5 w-5 text-success border-2 border-gray-300 focus:ring-0 active:ring-0"/>
+                                           class="input-checklist-dark"/>
                                     <div :class="[showIntern ? 'xsWhiteBold' : 'xsLight', 'my-auto ml-2']">
                                         {{ $t('Internal employees') }}
                                     </div>
@@ -111,7 +111,7 @@
                                 <div class="flex w-full mb-3">
                                     <input v-model="showExtern"
                                            type="checkbox"
-                                           class="cursor-pointer h-5 w-5 text-success border-2 border-gray-300 focus:ring-0 active:ring-0"/>
+                                           class="input-checklist-dark"/>
                                     <div :class="[showExtern ? 'xsWhiteBold' : 'xsLight', 'my-auto ml-2']">
                                         {{ $t('External employees') }}
                                     </div>
@@ -119,14 +119,14 @@
                                 <div class="flex w-full mb-3">
                                     <input v-model="showProvider"
                                            type="checkbox"
-                                           class="cursor-pointer h-5 w-5 text-success border-2 border-gray-300 focus:ring-0 active:ring-0"/>
+                                           class="input-checklist-dark"/>
                                     <div :class="[showProvider ? 'xsWhiteBold' : 'xsLight', 'my-auto ml-2']">
                                         {{ $t('Service provider') }}
                                     </div>
                                 </div>
                                 <div class="flex w-full mb-3" v-for="craft in crafts" :key="craft.id">
                                     <input type="checkbox"
-                                           class="cursor-pointer h-5 w-5 text-success border-2 border-gray-300 focus:ring-0 active:ring-0"
+                                           class="input-checklist-dark"
                                            v-model="activeCraftFilters"
                                            :id="'craft-' + craft.id"
                                            :value="craft.id"
@@ -141,7 +141,7 @@
                                             {{ $t('Search') }}
                                         </label>
                                         <div class="relative mt-2 rounded-md shadow-sm">
-                                            <input v-model="userSearch" type="text" name="account-number" id="account-number" class="block w-full border-0 py-1.5 pr-10 text-gray-900 ring-0  placeholder:text-gray-400 focus:ring-0 sm:text-sm sm:leading-6" />
+                                            <input v-model="userSearch" type="text" name="account-number" id="account-number" class="block w-full rounded-lg border border-gray-600 py-1.5 pr-10 text-white ring-0 bg-darkGrayBg placeholder:text-gray-400 focus:border-gray-500 focus:ring-0 sm:text-sm sm:leading-6" />
                                             <div class="absolute inset-y-0 right-0 flex items-center pr-3">
                                                 <IconSearch class="h-5 w-5 text-gray-400" aria-hidden="true" v-if="userSearch.length === 0" />
                                                 <IconX class="h-5 w-5 text-gray-400 cursor-pointer" aria-hidden="true" v-if="userSearch.length > 0" @click="userSearch = ''"/>

--- a/resources/js/Pages/Shifts/Components/CellMultiEditModal.vue
+++ b/resources/js/Pages/Shifts/Components/CellMultiEditModal.vue
@@ -163,14 +163,13 @@ const deleteIndividualTimeByIndex = (index) => {
 const submitForm = () => {
     multiEditCellForm.post(route('shift.plan.user.cell.update'), {
         preserveScroll: true,
-        preserveState: false,
+        preserveState: true,
         onSuccess: () => {
             showSaveSuccess.value = true
             setTimeout(() => {
                 showSaveSuccess.value = false
                 emit('close')
-            }, 1000)
-
+            }, 5000)
         }
     })
 }

--- a/resources/js/Pages/Shifts/Components/MultiEditUserCell.vue
+++ b/resources/js/Pages/Shifts/Components/MultiEditUserCell.vue
@@ -37,7 +37,7 @@
                 </div>
 
             </div>
-            <div class="flex items-center justify-end w-full gap-2 absolute right-2 top-2">
+            <div class="flex items-center justify-end w-fit gap-2 absolute right-2 top-2">
                 <div v-if="type === 0 && item.is_freelancer || type === 1">
                     <ToolTipComponent
                         icon="IconId"


### PR DESCRIPTION
- Menu when clicking on a user who is already added to a layer. 
- - This menu can now be used to replace the corresponding user 
- Menu when clicking on an empty shift person
- - This menu can be used to add a selected person.
- In all menus that open by clicking on a shift person or empty person, only the crafts of the shift and the crafts that can be used universally are displayed
- adding users to craft has been improved. 