### PR TITLE
refs #ARTWORK-293-fix-shiftplan-checkboxes

### DIFF
--- a/artwork/Modules/Shift/Models/Shift.php
+++ b/artwork/Modules/Shift/Models/Shift.php
@@ -238,7 +238,9 @@ class Shift extends Model
     ): Builder {
         return $builder
             ->whereBetween('event_start_day', [$eventStartDay, $eventEndDay])
-            ->orWhereBetween('event_end_day', [$eventStartDay, $eventEndDay]);
+            ->orWhereBetween('event_end_day', [$eventStartDay, $eventEndDay])
+            ->orWhereBetween('start_date', [$eventStartDay, $eventEndDay])
+            ->orWhereBetween('end_date', [$eventStartDay, $eventEndDay]);
     }
 
     public function scopeStartAndEndOverlap(Builder $builder, string $start, string $end): Builder

--- a/resources/js/Pages/Shifts/ShiftPlan.vue
+++ b/resources/js/Pages/Shifts/ShiftPlan.vue
@@ -1438,7 +1438,6 @@ export default {
                 (shift_id) => !this.userForMultiEdit.shift_ids.includes(shift_id)
             );
 
-            // Prüfen, ob Qualifikationen erforderlich sind
             if (this.userForMultiEdit.shift_qualifications.length > 0) {
                 this.userToMultiEditCheckedShiftsAndEvents.forEach((shiftAndEvent) => {
                     let desiredShift = shiftAndEvent.shift;
@@ -1491,7 +1490,6 @@ export default {
                 this.showShiftsQualificationsAssignmentModal = true;
                 this.waitForModalClose = true;
 
-                // Rückgabe einer Promise, die aufgelöst wird, wenn das Modal geschlossen wurde
                 return new Promise((resolve) => {
                     this.resolveModalClose = resolve;
                 });


### PR DESCRIPTION
- use shift dates beside event dates for workers shift-id determination
- boyscouting / cleanups