### PR TITLE
many fixes see description

### DIFF
--- a/resources/js/Components/FunctionBars/InventoryFunctionBar.vue
+++ b/resources/js/Components/FunctionBars/InventoryFunctionBar.vue
@@ -1,7 +1,64 @@
 <template>
     <div class="flex items-center w-full">
         <date-picker-component v-if="dateValue" :dateValueArray="dateValue" :is_shift_plan="false"></date-picker-component>
+
         <div class="flex items-center mx-4 gap-x-1 select-none">
+            <IconChevronLeftPipe stroke-width="1.5" class="h-7 w-7 text-artwork-buttons-context cursor-pointer" @click="previousTimeRange"/>
+            <IconChevronLeft stroke-width="1.5" class="h-7 w-7 text-artwork-buttons-context cursor-pointer" @click="scrollToPreviousDay"/>
+            <Menu as="div" class="relative inline-block text-left">
+                <div class="flex items-center">
+                    <MenuButton class="">
+                        <IconCalendarMonth stroke-width="1.5" class="h-5 w-5 text-artwork-buttons-context" v-if="$page.props.user.goto_mode === 'month'"/>
+                        <IconCalendarWeek stroke-width="1.5" class="h-5 w-5 text-artwork-buttons-context" v-if="$page.props.user.goto_mode === 'week'"/>
+                        <IconCalendar stroke-width="1.5" class="h-5 w-5 text-artwork-buttons-context" v-if="$page.props.user.goto_mode === 'day'"/>
+                    </MenuButton>
+                </div>
+
+                <transition enter-active-class="transition-enter-active"
+                            enter-from-class="transition-enter-from"
+                            enter-to-class="transition-enter-to"
+                            leave-active-class="transition-leave-active"
+                            leave-from-class="transition-leave-from"
+                            leave-to-class="transition-leave-to">
+                    <MenuItems class="absolute right-0 z-50 mt-2 w-fit origin-top-right rounded-md bg-artwork-navigation-background shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
+                        <div class="py-1">
+                            <MenuItem v-slot="{ active }">
+                                <div @click="changeUserSelectedGoTo('day')" :class="[active ? 'bg-artwork-navigation-color/10 text-white' : 'text-white', 'block px-4 py-2 text-sm']">
+                                    <ToolTipComponent
+                                        direction="right"
+                                        :tooltip-text="$t('Jump around') + ' ' + $t('Day')"
+                                        icon="IconCalendar"
+                                        icon-size="h-5 w-5 text-white" />
+                                </div>
+                            </MenuItem>
+                            <MenuItem v-slot="{ active }">
+                                <div @click="changeUserSelectedGoTo('week')" :class="[active ? 'bg-artwork-navigation-color/10 text-white' : 'text-white', 'block px-4 py-2 text-sm']">
+                                    <ToolTipComponent
+                                        direction="right"
+                                        :tooltip-text="$t('Jump around') + ' ' + $t('Calendar week')"
+                                        icon="IconCalendarWeek"
+                                        icon-size="h-5 w-5 text-white" />
+                                </div>
+                            </MenuItem>
+                            <MenuItem v-slot="{ active }">
+                                <div @click="changeUserSelectedGoTo('month')" :class="[active ? 'bg-artwork-navigation-color/10 text-white' : 'text-white', 'block px-4 py-2 text-sm']">
+                                    <ToolTipComponent
+                                        direction="right"
+                                        :tooltip-text="$t('Jump around') + ' ' + $t('Month')"
+                                        icon="IconCalendarMonth"
+                                        icon-size="h-5 w-5 text-white" />
+                                </div>
+                            </MenuItem>
+                        </div>
+                    </MenuItems>
+                </transition>
+            </Menu>
+            <IconChevronRight stroke-width="1.5" class="h-7 w-7 text-artwork-buttons-context cursor-pointer" @click="scrollToNextDay"/>
+
+            <IconChevronRightPipe stroke-width="1.5" class="h-7 w-7 text-artwork-buttons-context cursor-pointer"  @click="nextTimeRange"/>
+        </div>
+
+        <div class="flex items-center mx-4 gap-x-1 select-none invisible">
             <IconChevronLeft stroke-width="1.5" class="h-7 w-7 text-artwork-buttons-context cursor-pointer" @click="scrollToPreviousDay"/>
             <Menu as="div" class="relative inline-block text-left">
                 <div class="flex items-center">
@@ -42,6 +99,7 @@
                 </transition>
             </Menu>
             <IconChevronRight stroke-width="1.5" class="h-7 w-7 text-artwork-buttons-context cursor-pointer" @click="scrollToNextDay"/>
+
         </div>
 
 
@@ -51,9 +109,17 @@
 <script setup>
 
 import DatePickerComponent from "@/Layouts/Components/DatePickerComponent.vue";
-import {IconCalendar, IconCalendarMonth, IconCalendarWeek, IconChevronLeft, IconChevronRight} from "@tabler/icons-vue";
+import {
+    IconCalendar,
+    IconCalendarMonth,
+    IconCalendarWeek,
+    IconChevronLeft,
+    IconChevronLeftPipe,
+    IconChevronRight, IconChevronRightPipe
+} from "@tabler/icons-vue";
 import {MenuButton, Menu, MenuItems, MenuItem} from "@headlessui/vue";
 import {router, usePage} from "@inertiajs/vue3";
+import ToolTipComponent from "@/Components/ToolTips/ToolTipComponent.vue";
 
 const props = defineProps({
     dateValue: {
@@ -65,6 +131,8 @@ const props = defineProps({
 const emits = defineEmits([
     'scrollToPrevious',
     'scrollToNext',
+    'nextTimeRange',
+    'previousTimeRange'
 ])
 
 const changeUserSelectedGoTo = (type) => {
@@ -83,6 +151,16 @@ const scrollToPreviousDay = (event) => {
 const scrollToNextDay = (event) => {
     event.preventDefault();
     emits('scrollToNext');
+}
+
+const previousTimeRange = (event) => {
+    event.preventDefault();
+    emits('previousTimeRange');
+}
+
+const nextTimeRange = (event) => {
+    event.preventDefault();
+    emits('nextTimeRange');
 }
 
 </script>

--- a/resources/js/Components/ToolTips/ToolTipComponent.vue
+++ b/resources/js/Components/ToolTips/ToolTipComponent.vue
@@ -1,9 +1,9 @@
 <template>
-    <div class="flex items-center relative">
-        <button @mouseover="show = true" @mouseleave="show = false" class="focus:outline-none" :class="classes" :disabled="disabled">
+    <div class="flex items-center group relative">
+        <button class="focus:outline-none" :class="classes" :disabled="disabled">
             <component :is="icon" class=" cursor-pointer" :class="[iconSize, classes, whiteIcon ? 'text-white' : 'text-artwork-buttons-context']" :stroke-width="stroke"/>
         </button>
-        <div v-if="show">
+        <div class="hidden group-hover:block">
             <div v-if="direction === 'top'" class="absolute z-50 -top-3 text-center w-fit text-nowrap p-2 text-sm leading-tight text-white bg-black rounded-md shadow-lg transform -translate-x-1/2 -translate-y-full left-1/2">
                 {{ tooltipText }}
                 <div class="absolute bg-black h-3 w-3 transform rounded-sm rotate-45 left-1/2 -translate-x-1/2 -bottom-1.5"></div>

--- a/resources/js/Pages/Inventory/Components/SingleCategoryInCraft.vue
+++ b/resources/js/Pages/Inventory/Components/SingleCategoryInCraft.vue
@@ -1,7 +1,7 @@
 <template>
     <tr class="cursor-pointer xsLight pb-1" @click="category.closed = !category.closed">
        <td>
-           <div class="py-1.5 bg-gray-50/20 w-full" :class="category.closed ? 'rounded-b-lg' : ''">
+           <div class="py-1.5 bg-gray-50/20 w-full" >
                <div class="stickyYAxisNoMarginLeft w-48 flex items-center gap-x-1">
                    <component is="IconCategory" class="h-4 w-4" />
                    {{ category.name }}
@@ -37,7 +37,8 @@ const props = defineProps({
     },
     inventory_planer_ids: {
         type: Array,
-        required: true,
+        required: false,
+        default: []
     },
     inventory_planned_by_all: {
         type: Boolean,

--- a/resources/js/Pages/Inventory/Components/SingleCraftInUserOverview.vue
+++ b/resources/js/Pages/Inventory/Components/SingleCraftInUserOverview.vue
@@ -1,7 +1,7 @@
 <template>
     <tr class="pl-2 h-full cursor-pointer w-full xsLight pb-1" @click="craft.value.closed = !craft.value.closed">
         <td>
-            <div class="py-2.5 px-2 bg-gray-50/30 w-full" :class="craft.value.closed ? 'rounded-lg' : 'rounded-t-lg'">
+            <div class="py-2.5 px-2  w-full" :class="craft.value.closed ? 'rounded-lg' : 'rounded-t-lg'">
                 <div class="flex stickyYAxisNoMarginLeft w-48 items-center gap-x-2">
                     {{craft.value.name}}
                     <ChevronDownIcon

--- a/resources/js/Pages/Inventory/Components/SingleFolderInGroup.vue
+++ b/resources/js/Pages/Inventory/Components/SingleFolderInGroup.vue
@@ -13,7 +13,7 @@
             </div>
         </td>
     </tr>
-    <SingleItemInGroup :inventory_planned_by_all="inventory_planned_by_all" :craft="craft" :multi-edit="multiEdit" v-for="item in folder.items" :days="days" :item="item" v-if="!folder.closed"/>
+    <SingleItemInGroup :inventory_planned_by_all="inventory_planned_by_all" :inventory_planer_ids="inventory_planer_ids" :multi-edit="multiEdit" v-for="item in folder.items" :days="days" :item="item" v-if="!folder.closed"/>
 </template>
 
 <script setup>
@@ -37,7 +37,8 @@ const props = defineProps({
     },
     inventory_planer_ids: {
         type: Array,
-        required: true,
+        required: false,
+        default: []
     },
     inventory_planned_by_all: {
         type: Boolean,

--- a/resources/js/Pages/Inventory/Components/SingleGroupInCategory.vue
+++ b/resources/js/Pages/Inventory/Components/SingleGroupInCategory.vue
@@ -39,7 +39,8 @@ const props = defineProps({
     },
     inventory_planer_ids: {
         type: Array,
-        required: true,
+        required: false,
+        default: []
     },
     inventory_planned_by_all: {
         type: Boolean,

--- a/resources/js/Pages/Inventory/Components/SingleItemInGroup.vue
+++ b/resources/js/Pages/Inventory/Components/SingleItemInGroup.vue
@@ -47,7 +47,8 @@ const props = defineProps({
     },
     inventory_planer_ids: {
         type: Array,
-        required: true,
+        required: false,
+        default: []
     },
     inventory_planned_by_all: {
         type: Boolean,

--- a/resources/js/Pages/Inventory/InventoryManagement/InventoryItem.vue
+++ b/resources/js/Pages/Inventory/InventoryManagement/InventoryItem.vue
@@ -1,9 +1,8 @@
 <template>
-    <tr @mouseover="showItemMenu()" @mouseout="closeItemMenu()" class="cursor-grab group" :id="'item_' + item.id"  draggable="true" @dragstart="onDragStart">
+    <tr @mouseover="showItemMenu()" @mouseout="closeItemMenu()" class="cursor-grab group" :id="'item_' + item.id"  :draggable="canDraggable" @dragstart="onDragStart">
         <template v-for="(cell) in item.cells"
                   :key="cell.id">
-            <InventoryCell :cell="cell"
-                           @is-editing-cell-value="handleCellIsEditing"/>
+            <InventoryCell :cell="cell" @is-editing-cell-value="handleCellIsEditing"/>
         </template>
         <td class="relative">
             <div class="absolute right-0 group-hover:visible invisible top-2" v-if="can('can manage inventory stock') || hasAdminRole()">
@@ -41,8 +40,15 @@ import {usePermission} from "@/Composeables/Permission.js";
 import {usePage} from "@inertiajs/vue3";
 const { can, canAny, hasAdminRole } = usePermission(usePage().props);
 
+const canDraggable = computed(() => {
+    return inventoryCellsEditing.value.length === 0;
+});
 const onDragStart = (event) => {
     if(!can('can manage inventory stock') || !hasAdminRole()){
+        return;
+    }
+
+    if (inventoryCellsEditing.value.length > 0) {
         return;
     }
 

--- a/resources/js/Pages/Inventory/InventoryManagement/InventoryItemCell.vue
+++ b/resources/js/Pages/Inventory/InventoryManagement/InventoryItemCell.vue
@@ -33,7 +33,7 @@
                 </div>
             </template>
             <template v-else-if="isLastEditField()">
-                <div class="flex items-center gap-1">
+                <div class="flex items-center gap-1 cursor-grab">
                     {{ computedJsonValue.date }}
                     <div class="flex items-center gap-1">
                         <UserPopoverTooltip :user="computedJsonValue.editor" height="5" width="5"/>
@@ -215,7 +215,7 @@ const emits = defineEmits(['isEditingCellValue']),
 
         if (cellClicked.value) {
             setTimeout(() => {
-                if (isTextColumn()) {
+                if (isTextColumn() || isNumberColumn()) {
                     cellValueInputRef.value.select();
                     return;
                 }

--- a/resources/js/Pages/Shifts/Components/CellMultiEditModal.vue
+++ b/resources/js/Pages/Shifts/Components/CellMultiEditModal.vue
@@ -125,7 +125,7 @@ const submitForm = () => {
             showSaveSuccess.value = true;
             setTimeout(() => {
                 showSaveSuccess.value = false;
-                emit('close');
+                emit('close', true);
             }, 2500)
 
         }

--- a/resources/js/Pages/Shifts/Components/DeleteEntriesModal.vue
+++ b/resources/js/Pages/Shifts/Components/DeleteEntriesModal.vue
@@ -1,5 +1,5 @@
 <template>
-    <BaseModal @closed="$emit('close')">
+    <BaseModal @closed="$emit('close', {closing: true})">
         <ModalHeader
             title="Löschen"
             description="Alle Einträge (inklusive Schichten) für die ausgewählten Termine löschen?"

--- a/resources/js/Pages/Shifts/ShiftPlan.vue
+++ b/resources/js/Pages/Shifts/ShiftPlan.vue
@@ -127,44 +127,35 @@
                     <div v-show="showUserOverview" ref="userOverview"
                          class="relative w-[97%] bg-artwork-navigation-background overflow-x-scroll z-20 overflow-y-scroll"
                          :style="showUserOverview ? { height: userOverviewHeight + 'px'} : {height: 20 + 'px'}">
-                        <div
-                            class="flex items-center justify-between w-full fixed py-3 z-20 bg-artwork-navigation-background px-3"
-                            :style="{top: calculateTopPositionOfUserOverView}">
+                        <div class="flex items-center justify-between w-full fixed py-3 z-20 bg-artwork-navigation-background px-3" :style="{top: calculateTopPositionOfUserOverView}">
                             <div class="flex items-center justify-end gap-x-3">
-                                <Switch @click="toggleMultiEditMode" v-model="multiEditMode"
-                                        :class="[multiEditMode ? 'bg-artwork-buttons-hover' : 'bg-gray-200', 'relative inline-flex items-center h-5 w-10 flex-shrink-0 cursor-pointer rounded-full transition-colors duration-200 ease-in-out focus:outline-none focus:ring-none']">
-                                    <span class="sr-only">Use setting</span>
-                                    <span :class="[multiEditMode ? 'translate-x-5' : 'translate-x-0', 'relative inline-block h-6 w-6 border border-gray-300 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out']">
-                                      <span
-                                          :class="[multiEditMode ? 'opacity-0 duration-100 ease-out' : 'opacity-100 duration-200 ease-in', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']"
-                                          aria-hidden="true">
-                                          <ToolTipComponent
-                                              icon="IconPencil"
-                                              icon-size="h-4 w-4"
-                                              :tooltip-text="$t('Edit')"
-                                              direction="right"
-                                          />
-                                      </span>
-                                      <span
-                                          :class="[multiEditMode ? 'opacity-100 duration-200 ease-in' : 'opacity-0 duration-100 ease-out', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']"
-                                          aria-hidden="true">
-                                          <ToolTipComponent
-                                              icon="IconPencil"
-                                              icon-size="h-4 w-4"
-                                              :tooltip-text="$t('Edit')"
-                                              direction="right"
-                                          />
-                                      </span>
-                                </span>
+                                <Switch @click="toggleMultiEditMode" v-model="multiEditMode" :class="[multiEditMode ? 'bg-artwork-buttons-hover' : 'bg-gray-200', 'relative inline-flex items-center h-5 w-10 flex-shrink-0 cursor-pointer rounded-full transition-colors duration-200 ease-in-out focus:outline-none focus:ring-none']">
+                                    <span :class="[multiEditMode ? 'translate-x-5' : 'translate-x-0', 'inline-block h-6 w-6 border border-gray-300 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out']">
+                                        <span :class="[multiEditMode ? 'opacity-0 duration-100 ease-out' : 'opacity-100 duration-200 ease-in z-20', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']" aria-hidden="true">
+                                            <ToolTipComponent
+                                                icon="IconPencil"
+                                                icon-size="h-4 w-4"
+                                                :tooltip-text="$t('Edit')"
+                                                direction="right"
+                                            />
+                                        </span>
+                                        <span :class="[multiEditMode ? 'opacity-100 duration-200 ease-in z-20' : 'opacity-0 duration-100 ease-out', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']" aria-hidden="true">
+                                            <ToolTipComponent
+                                                icon="IconPencil"
+                                                icon-size="h-4 w-4"
+                                                :tooltip-text="$t('Edit')"
+                                                direction="right"
+                                            />
+                                        </span>
+                                    </span>
                                 </Switch>
                                 <div class="flex items-center gap-x-2" v-if="dayServices && selectedDayService">
                                     <Switch @click="toggleDayServiceMode" v-model="dayServiceMode"
                                             :class="[dayServiceMode ? 'bg-artwork-buttons-hover' : 'bg-gray-200', 'relative z-20 inline-flex items-center h-5 w-10 flex-shrink-0 cursor-pointer rounded-full transition-colors duration-200 ease-in-out focus:outline-none focus:ring-none']">
                                         <span class="sr-only">Use setting</span>
+                                        <span :class="[dayServiceMode ? 'translate-x-5' : 'translate-x-0', 'relative inline-block h-6 w-6 border border-gray-300 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out']">
                                         <span
-                                            :class="[dayServiceMode ? 'translate-x-5' : 'translate-x-0', 'relative inline-block h-6 w-6 border border-gray-300 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out']">
-                                        <span
-                                            :class="[dayServiceMode ? 'opacity-0 duration-100 ease-out' : 'opacity-100 duration-200 ease-in', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']"
+                                            :class="[dayServiceMode ? 'opacity-0 duration-100 ease-out' : 'opacity-100 duration-200 ease-in z-20', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']"
                                             aria-hidden="true">
                                             <ToolTipComponent
                                                 :icon="selectedDayService?.icon"
@@ -175,7 +166,7 @@
                                             />
                                         </span>
                                         <span
-                                            :class="[dayServiceMode ? 'opacity-100 duration-200 ease-in' : 'opacity-0 duration-100 ease-out', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']"
+                                            :class="[dayServiceMode ? 'opacity-100 duration-200 ease-in z-20' : 'opacity-0 duration-100 ease-out', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']"
                                             aria-hidden="true">
                                             <ToolTipComponent
                                                 :icon="selectedDayService?.icon"
@@ -261,7 +252,7 @@
                                     <span
                                         :class="[highlightMode ? 'translate-x-5' : 'translate-x-0', 'relative inline-block h-6 w-6 border border-gray-300 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out']">
                                       <span
-                                          :class="[highlightMode ? 'opacity-0 duration-100 ease-out' : 'opacity-100 duration-200 ease-in', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']"
+                                          :class="[highlightMode ? 'opacity-0 duration-100 ease-out' : 'opacity-100 duration-200 ease-in z-20', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']"
                                           aria-hidden="true">
                                           <ToolTipComponent
                                               icon="IconBulb"
@@ -271,7 +262,7 @@
                                           />
                                       </span>
                                       <span
-                                          :class="[highlightMode ? 'opacity-100 duration-200 ease-in' : 'opacity-0 duration-100 ease-out', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']"
+                                          :class="[highlightMode ? 'opacity-100 duration-200 ease-in z-20' : 'opacity-0 duration-100 ease-out', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']"
                                           aria-hidden="true">
                                           <ToolTipComponent
                                               icon="IconBulb"
@@ -288,7 +279,7 @@
                                     <span
                                         :class="[$page.props.user.compact_mode ? 'translate-x-5' : 'translate-x-0', 'relative inline-block h-6 w-6 border border-gray-300 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out']">
                                       <span
-                                          :class="[$page.props.user.compact_mode ? 'opacity-0 duration-100 ease-out' : 'opacity-100 duration-200 ease-in', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']"
+                                          :class="[$page.props.user.compact_mode ? 'opacity-0 duration-100 ease-out' : 'opacity-100 duration-200 ease-in z-20', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']"
                                           aria-hidden="true">
                                           <ToolTipComponent
                                               icon="IconList"
@@ -298,7 +289,7 @@
                                           />
                                       </span>
                                       <span
-                                          :class="[$page.props.user.compact_mode ? 'opacity-100 duration-200 ease-in' : 'opacity-0 duration-100 ease-out', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']"
+                                          :class="[$page.props.user.compact_mode ? 'opacity-100 duration-200 ease-in z-20' : 'opacity-0 duration-100 ease-out', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']"
                                           aria-hidden="true">
                                           <ToolTipComponent
                                               icon="IconList"
@@ -1423,8 +1414,11 @@ export default {
                 this.multiEditCellByDayAndUser = {};
             }
         },
-        closeMultiEditCellModal(){
+        closeMultiEditCellModal(bool){
             this.showCellMultiEditModal = false;
+
+
+
             handleReload(
                 this.rooms.map(room => room.id),
                 this.days.map(day => day.full_day),
@@ -1435,13 +1429,25 @@ export default {
                     }
                 })
             );
+
+            if (bool) {
+                this.multiEditCellByDayAndUser = {};
+            }
         },
         closeCellMultiEditDelete(boolean) {
+
+
+            if(boolean.closing) {
+                this.openCellMultiEditDelete = false;
+                return;
+            }
+
             this.openCellMultiEditDelete = false;
 
             if(boolean) {
                 this.showCellMultiEditModal = true;
             }
+
             handleReload(
                 this.rooms.map(room => room.id),
                 this.days.map(day => day.full_day),
@@ -1452,6 +1458,10 @@ export default {
                     }
                 })
             );
+
+            if (!boolean) {
+                this.multiEditCellByDayAndUser = {};
+            }
         },
         toggleDayServiceMode() {
             this.highlightMode = false;


### PR DESCRIPTION
- Design customisations. Inventory planning now looks like the shift plan 
- tooltips in the shift plan have been fixed and now work as intended
- The behaviour of the modal for multiedit has been adjusted and now works as desired
- An error has been fixed so that the room names are now always displayed correctly in the inventory planning 