### PR TITLE
refs ARTWORK-323-notification-immediately-frequency

### DIFF
--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -81,8 +81,6 @@ class TaskController extends Controller
         /** @var Checklist $checklist */
         $checklist = $this->checklistService->getById($request->integer('checklist_id'));
 
-        //dd($request);
-
         $this->taskService->createTaskByRequest(
             $checklist,
             $request->string('name'),

--- a/artwork/Core/Notifications/BaseNotification.php
+++ b/artwork/Core/Notifications/BaseNotification.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Artwork\Core\Notifications;
+
+use Artwork\Modules\Notification\Enums\NotificationFrequencyEnum;
+use Artwork\Modules\Notification\Models\NotificationSetting;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Notifications\Messages\BroadcastMessage;
+use Illuminate\Notifications\Notification;
+use stdClass;
+
+class BaseNotification extends Notification implements ShouldBroadcast
+{
+    use Queueable;
+
+    protected ?stdClass $notificationData = null;
+
+    protected array $broadcastMessage = [];
+
+    public function __construct($notificationData, $broadcastMessage = [])
+    {
+        $this->notificationData = $notificationData;
+        $this->broadcastMessage = $broadcastMessage;
+    }
+
+    public function toBroadcast(): BroadcastMessage
+    {
+        return new BroadcastMessage([
+            'message' => $this->broadcastMessage
+        ]);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function via($user): array
+    {
+        $channels = ['database'];
+
+        /** @var NotificationSetting $typeSettings */
+        $notificationSetting = $user->notificationSettings()
+            ->where('type', $this->notificationData->type)
+            ->first();
+
+        if (is_null($notificationSetting)) {
+            return $channels;
+        }
+
+        if (
+            $notificationSetting->getAttribute('enabled_email') &&
+            $notificationSetting->getAttribute('frequency') === NotificationFrequencyEnum::IMMEDIATELY
+        ) {
+            $channels[] = 'mail';
+        }
+
+        if (!empty($this->broadcastMessage) && $notificationSetting->getAttribute('enabled_push')) {
+            $channels[] = 'broadcast';
+        }
+
+        return $channels;
+    }
+
+    public function toArray(): stdClass
+    {
+        return $this->notificationData;
+    }
+}

--- a/artwork/Modules/Budget/Notifications/BudgetVerified.php
+++ b/artwork/Modules/Budget/Notifications/BudgetVerified.php
@@ -2,60 +2,15 @@
 
 namespace Artwork\Modules\Budget\Notifications;
 
+use Artwork\Core\Notifications\BaseNotification;
 use Artwork\Modules\GeneralSettings\Models\GeneralSettings;
-use Illuminate\Bus\Queueable;
 use Illuminate\Config\Repository;
-use Illuminate\Notifications\Messages\BroadcastMessage;
 use Illuminate\Notifications\Messages\MailMessage;
-use Illuminate\Notifications\Notification;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\NotFoundExceptionInterface;
-use stdClass;
 
-class BudgetVerified extends Notification
+class BudgetVerified extends BaseNotification
 {
-    use Queueable;
-
-    protected ?stdClass $notificationData = null;
-
-    protected array $broadcastMessage = [];
-
-    public function __construct($notificationData, array $broadcastMessage = [])
-    {
-        $this->notificationData = $notificationData;
-        $this->broadcastMessage = $broadcastMessage;
-    }
-
-    public function toBroadcast(): BroadcastMessage
-    {
-        return new BroadcastMessage([
-            'message' => $this->broadcastMessage
-        ]);
-    }
-
-
-    /**
-     * @return string[]
-     */
-    public function via($user): array
-    {
-        $channels = ['database'];
-
-        $typeSettings = $user->notificationSettings()
-            ->where('type', $this->notificationData->type)
-            ->first();
-
-//        if ($typeSettings?->enabled_email) {
-//            $channels[] = 'mail';
-//        }
-
-        if ($typeSettings?->enabled_push && !empty($this->broadcastMessage)) {
-            $channels[] = 'broadcast';
-        }
-
-        return $channels;
-    }
-
     /**
      * @throws ContainerExceptionInterface
      * @throws NotFoundExceptionInterface
@@ -80,10 +35,5 @@ class BudgetVerified extends Notification
                     'pageTitle' => $pageTitle,
                 ]
             );
-    }
-
-    public function toArray(): stdClass
-    {
-        return $this->notificationData;
     }
 }

--- a/artwork/Modules/Department/Notifications/TeamNotification.php
+++ b/artwork/Modules/Department/Notifications/TeamNotification.php
@@ -2,60 +2,15 @@
 
 namespace Artwork\Modules\Department\Notifications;
 
+use Artwork\Core\Notifications\BaseNotification;
 use Artwork\Modules\GeneralSettings\Models\GeneralSettings;
-use Illuminate\Bus\Queueable;
 use Illuminate\Config\Repository;
-use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
-use Illuminate\Notifications\Messages\BroadcastMessage;
 use Illuminate\Notifications\Messages\MailMessage;
-use Illuminate\Notifications\Notification;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\NotFoundExceptionInterface;
-use stdClass;
 
-class TeamNotification extends Notification implements ShouldBroadcast
+class TeamNotification extends BaseNotification
 {
-    use Queueable;
-
-    protected ?stdClass $notificationData = null;
-
-    protected array $broadcastMessage = [];
-
-    public function __construct($notificationData, $broadcastMessage = [])
-    {
-        $this->notificationData = $notificationData;
-        $this->broadcastMessage = $broadcastMessage;
-    }
-
-    public function toBroadcast(): BroadcastMessage
-    {
-        return new BroadcastMessage([
-            'message' => $this->broadcastMessage
-        ]);
-    }
-
-    /**
-     * @return string[]
-     */
-    public function via($user): array
-    {
-        $channels = ['database'];
-
-        $typeSettings = $user->notificationSettings()
-            ->where('type', $this->notificationData->type)
-            ->first();
-
-//        if ($typeSettings?->enabled_email) {
-//            $channels[] = 'mail';
-//        }
-
-        if ($typeSettings?->enabled_push && !empty($this->broadcastMessage)) {
-            $channels[] = 'broadcast';
-        }
-
-        return $channels;
-    }
-
     /**
      * @throws ContainerExceptionInterface
      * @throws NotFoundExceptionInterface
@@ -79,10 +34,5 @@ class TeamNotification extends Notification implements ShouldBroadcast
                     'pageTitle' => $pageTitle,
                 ]
             );
-    }
-
-    public function toArray(): stdClass
-    {
-        return $this->notificationData;
     }
 }

--- a/artwork/Modules/Event/Notifications/ConflictNotification.php
+++ b/artwork/Modules/Event/Notifications/ConflictNotification.php
@@ -2,60 +2,15 @@
 
 namespace Artwork\Modules\Event\Notifications;
 
+use Artwork\Core\Notifications\BaseNotification;
 use Artwork\Modules\GeneralSettings\Models\GeneralSettings;
-use Illuminate\Bus\Queueable;
 use Illuminate\Config\Repository;
-use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
-use Illuminate\Notifications\Messages\BroadcastMessage;
 use Illuminate\Notifications\Messages\MailMessage;
-use Illuminate\Notifications\Notification;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\NotFoundExceptionInterface;
-use stdClass;
 
-class ConflictNotification extends Notification implements ShouldBroadcast
+class ConflictNotification extends BaseNotification
 {
-    use Queueable;
-
-    protected ?stdClass $notificationData = null;
-
-    protected array $broadcastMessage = [];
-
-    public function __construct($notificationData, array $broadcastMessage = [])
-    {
-        $this->notificationData = $notificationData;
-        $this->broadcastMessage = $broadcastMessage;
-    }
-
-    public function toBroadcast(): BroadcastMessage
-    {
-        return new BroadcastMessage([
-            'message' => $this->broadcastMessage
-        ]);
-    }
-
-    /**
-     * @return string[]
-     */
-    public function via($user): array
-    {
-        $channels = ['database'];
-
-        $typeSettings = $user->notificationSettings()
-            ->where('type', $this->notificationData->type)
-            ->first();
-
-//        if ($typeSettings?->enabled_email) {
-//            $channels[] = 'mail';
-//        }
-
-        if ($typeSettings?->enabled_push && !empty($this->broadcastMessage)) {
-            $channels[] = 'broadcast';
-        }
-
-        return $channels;
-    }
-
     /**
      * @throws ContainerExceptionInterface
      * @throws NotFoundExceptionInterface
@@ -79,10 +34,5 @@ class ConflictNotification extends Notification implements ShouldBroadcast
                     'pageTitle' => $pageTitle,
                 ]
             );
-    }
-
-    public function toArray(): stdClass
-    {
-        return $this->notificationData;
     }
 }

--- a/artwork/Modules/Event/Notifications/EventNotification.php
+++ b/artwork/Modules/Event/Notifications/EventNotification.php
@@ -2,60 +2,15 @@
 
 namespace Artwork\Modules\Event\Notifications;
 
+use Artwork\Core\Notifications\BaseNotification;
 use Artwork\Modules\GeneralSettings\Models\GeneralSettings;
-use Illuminate\Bus\Queueable;
 use Illuminate\Config\Repository;
-use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
-use Illuminate\Notifications\Messages\BroadcastMessage;
 use Illuminate\Notifications\Messages\MailMessage;
-use Illuminate\Notifications\Notification;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\NotFoundExceptionInterface;
-use stdClass;
 
-class EventNotification extends Notification implements ShouldBroadcast
+class EventNotification extends BaseNotification
 {
-    use Queueable;
-
-    protected ?stdClass $notificationData = null;
-
-    protected array $broadcastMessage = [];
-
-    public function __construct($notificationData, $broadcastMessage = [])
-    {
-        $this->notificationData = $notificationData;
-        $this->broadcastMessage = $broadcastMessage;
-    }
-
-    public function toBroadcast(): BroadcastMessage
-    {
-        return new BroadcastMessage([
-            'message' => $this->broadcastMessage
-        ]);
-    }
-
-    /**
-     * @return string[]
-     */
-    public function via($user): array
-    {
-        $channels = ['database'];
-
-        $typeSettings = $user->notificationSettings()
-            ->where('type', $this->notificationData->type)
-            ->first();
-
-//        if ($typeSettings?->enabled_email) {
-//            $channels[] = 'mail';
-//        }
-
-        if ($typeSettings?->enabled_push && !empty($this->broadcastMessage)) {
-            $channels[] = 'broadcast';
-        }
-
-        return $channels;
-    }
-
     /**
      * @throws ContainerExceptionInterface
      * @throws NotFoundExceptionInterface
@@ -79,10 +34,5 @@ class EventNotification extends Notification implements ShouldBroadcast
                     'pageTitle' => $pageTitle,
                 ]
             );
-    }
-
-    public function toArray(): stdClass
-    {
-        return $this->notificationData;
     }
 }

--- a/artwork/Modules/InventoryManagement/Services/CraftInventoryItemCellService.php
+++ b/artwork/Modules/InventoryManagement/Services/CraftInventoryItemCellService.php
@@ -55,7 +55,6 @@ class CraftInventoryItemCellService
         // update last edit column with current date and user
 
         $column = CraftsInventoryColumn::where('type', CraftsInventoryColumnTypeEnum::LAST_EDIT_AND_EDITOR)->first();
-        //dd($column);
 
         $cell = CraftInventoryItemCell::where(
             'craft_inventory_item_id',

--- a/artwork/Modules/MoneySource/Notifications/MoneySourceNotification.php
+++ b/artwork/Modules/MoneySource/Notifications/MoneySourceNotification.php
@@ -2,61 +2,15 @@
 
 namespace Artwork\Modules\MoneySource\Notifications;
 
+use Artwork\Core\Notifications\BaseNotification;
 use Artwork\Modules\GeneralSettings\Models\GeneralSettings;
-use Illuminate\Bus\Queueable;
 use Illuminate\Config\Repository;
-use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
-use Illuminate\Notifications\Messages\BroadcastMessage;
 use Illuminate\Notifications\Messages\MailMessage;
-use Illuminate\Notifications\Notification;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\NotFoundExceptionInterface;
-use stdClass;
 
-class MoneySourceNotification extends Notification implements ShouldBroadcast
+class MoneySourceNotification extends BaseNotification
 {
-    use Queueable;
-
-    protected ?stdClass $notificationData = null;
-
-    protected array $broadcastMessage = [];
-
-    public function __construct($notificationData, $broadcastMessage = [])
-    {
-        $this->notificationData = $notificationData;
-        $this->broadcastMessage = $broadcastMessage;
-    }
-
-    public function toBroadcast(): BroadcastMessage
-    {
-        return new BroadcastMessage([
-            'message' => $this->broadcastMessage
-        ]);
-    }
-
-    /**
-     * @return string[]
-     */
-    public function via($user): array
-    {
-        $channels = ['database'];
-
-        $typeSettings = $user->notificationSettings()
-            ->where('type', $this->notificationData->type)
-            ->first();
-
-//        if ($typeSettings?->enabled_email) {
-//            $channels[] = 'mail';
-//        }
-
-
-        if ($typeSettings?->enabled_push && !empty($this->broadcastMessage)) {
-            $channels[] = 'broadcast';
-        }
-
-        return $channels;
-    }
-
     /**
      * @throws ContainerExceptionInterface
      * @throws NotFoundExceptionInterface
@@ -80,10 +34,5 @@ class MoneySourceNotification extends Notification implements ShouldBroadcast
                     'pageTitle' => $pageTitle,
                 ]
             );
-    }
-
-    public function toArray(): stdClass
-    {
-        return $this->notificationData;
     }
 }

--- a/artwork/Modules/Notification/Enums/NotificationFrequencyEnum.php
+++ b/artwork/Modules/Notification/Enums/NotificationFrequencyEnum.php
@@ -4,13 +4,18 @@ namespace Artwork\Modules\Notification\Enums;
 
 enum NotificationFrequencyEnum: string
 {
-    case DAILY       = 'daily';
-    case WEEKLY_TWICE    = 'weekly_twice';
-    case WEEKLY_ONCE     = 'weekly_once';
+    case IMMEDIATELY = 'Immediately';
+
+    case DAILY = 'daily';
+
+    case WEEKLY_TWICE = 'weekly_twice';
+
+    case WEEKLY_ONCE = 'weekly_once';
 
     public function title(): string
     {
         return match ($this) {
+            self::IMMEDIATELY => 'Immediately',
             self::DAILY => "Daily",
             self::WEEKLY_TWICE => "Twice a week",
             self::WEEKLY_ONCE => "Once a week",

--- a/artwork/Modules/Notification/Services/NotificationService.php
+++ b/artwork/Modules/Notification/Services/NotificationService.php
@@ -333,6 +333,7 @@ class NotificationService
         if (!$this->getNotificationTo()) {
             return;
         }
+
         $body = new stdClass();
         $body->icon = 'gray';
         $body->priority = $this->getPriority();

--- a/artwork/Modules/Project/Notifications/ProjectNotification.php
+++ b/artwork/Modules/Project/Notifications/ProjectNotification.php
@@ -2,60 +2,15 @@
 
 namespace Artwork\Modules\Project\Notifications;
 
+use Artwork\Core\Notifications\BaseNotification;
 use Artwork\Modules\GeneralSettings\Models\GeneralSettings;
-use Illuminate\Bus\Queueable;
 use Illuminate\Config\Repository;
-use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
-use Illuminate\Notifications\Messages\BroadcastMessage;
 use Illuminate\Notifications\Messages\MailMessage;
-use Illuminate\Notifications\Notification;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\NotFoundExceptionInterface;
-use stdClass;
 
-class ProjectNotification extends Notification implements ShouldBroadcast
+class ProjectNotification extends BaseNotification
 {
-    use Queueable;
-
-    protected ?stdClass $notificationData = null;
-
-    protected array $broadcastMessage = [];
-
-    public function __construct($notificationData, $broadcastMessage = [])
-    {
-        $this->notificationData = $notificationData;
-        $this->broadcastMessage = $broadcastMessage;
-    }
-
-    public function toBroadcast(): BroadcastMessage
-    {
-        return new BroadcastMessage([
-            'message' => $this->broadcastMessage
-        ]);
-    }
-
-    /**
-     * @return string[]
-     */
-    public function via($user): array
-    {
-        $channels = ['database'];
-
-        $typeSettings = $user->notificationSettings()
-            ->where('type', $this->notificationData->type)
-            ->first();
-
-//        if ($typeSettings?->enabled_email) {
-//            $channels[] = 'mail';
-//        }
-
-        if ($typeSettings?->enabled_push && !empty($this->broadcastMessage)) {
-            $channels[] = 'broadcast';
-        }
-
-        return $channels;
-    }
-
     /**
      * @throws ContainerExceptionInterface
      * @throws NotFoundExceptionInterface
@@ -79,10 +34,5 @@ class ProjectNotification extends Notification implements ShouldBroadcast
                     'pageTitle' => $pageTitle,
                 ]
             );
-    }
-
-    public function toArray(): stdClass
-    {
-        return $this->notificationData;
     }
 }

--- a/artwork/Modules/Room/Notifications/RoomNotification.php
+++ b/artwork/Modules/Room/Notifications/RoomNotification.php
@@ -2,60 +2,15 @@
 
 namespace Artwork\Modules\Room\Notifications;
 
+use Artwork\Core\Notifications\BaseNotification;
 use Artwork\Modules\GeneralSettings\Models\GeneralSettings;
-use Illuminate\Bus\Queueable;
 use Illuminate\Config\Repository;
-use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
-use Illuminate\Notifications\Messages\BroadcastMessage;
 use Illuminate\Notifications\Messages\MailMessage;
-use Illuminate\Notifications\Notification;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\NotFoundExceptionInterface;
-use stdClass;
 
-class RoomNotification extends Notification implements ShouldBroadcast
+class RoomNotification extends BaseNotification
 {
-    use Queueable;
-
-    protected ?stdClass $notificationData = null;
-
-    protected array $broadcastMessage = [];
-
-    public function __construct($notificationData, $broadcastMessage = [])
-    {
-        $this->notificationData = $notificationData;
-        $this->broadcastMessage = $broadcastMessage;
-    }
-
-    public function toBroadcast(): BroadcastMessage
-    {
-        return new BroadcastMessage([
-            'message' => $this->broadcastMessage
-        ]);
-    }
-
-    /**
-     * @return string[]
-     */
-    public function via($user): array
-    {
-        $channels = ['database'];
-
-        $typeSettings = $user->notificationSettings()
-            ->where('type', $this->notificationData->type)
-            ->first();
-
-//        if ($typeSettings?->enabled_email) {
-//            $channels[] = 'mail';
-//        }
-
-        if ($typeSettings?->enabled_push && !empty($this->broadcastMessage)) {
-            $channels[] = 'broadcast';
-        }
-
-        return $channels;
-    }
-
     /**
      * @throws ContainerExceptionInterface
      * @throws NotFoundExceptionInterface
@@ -79,10 +34,5 @@ class RoomNotification extends Notification implements ShouldBroadcast
                     'pageTitle' => $pageTitle,
                 ]
             );
-    }
-
-    public function toArray(): object
-    {
-        return (object)$this->notificationData;
     }
 }

--- a/artwork/Modules/Room/Notifications/RoomRequestNotification.php
+++ b/artwork/Modules/Room/Notifications/RoomRequestNotification.php
@@ -2,60 +2,15 @@
 
 namespace Artwork\Modules\Room\Notifications;
 
+use Artwork\Core\Notifications\BaseNotification;
 use Artwork\Modules\GeneralSettings\Models\GeneralSettings;
-use Illuminate\Bus\Queueable;
 use Illuminate\Config\Repository;
-use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
-use Illuminate\Notifications\Messages\BroadcastMessage;
 use Illuminate\Notifications\Messages\MailMessage;
-use Illuminate\Notifications\Notification;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\NotFoundExceptionInterface;
-use stdClass;
 
-class RoomRequestNotification extends Notification implements ShouldBroadcast
+class RoomRequestNotification extends BaseNotification
 {
-    use Queueable;
-
-    protected ?stdClass $notificationData = null;
-
-    protected array $broadcastMessage = [];
-
-    public function __construct($notificationData, $broadcastMessage = [])
-    {
-        $this->notificationData = $notificationData;
-        $this->broadcastMessage = $broadcastMessage;
-    }
-
-    public function toBroadcast(): BroadcastMessage
-    {
-        return new BroadcastMessage([
-            'message' => $this->broadcastMessage
-        ]);
-    }
-
-    /**
-     * @return string[]
-     */
-    public function via($user): array
-    {
-        $channels = ['database'];
-
-        $typeSettings = $user->notificationSettings()
-            ->where('type', $this->notificationData->type)
-            ->first();
-
-//        if ($typeSettings?->enabled_email) {
-//            $channels[] = 'mail';
-//        }
-
-        if ($typeSettings?->enabled_push && !empty($this->broadcastMessage)) {
-            $channels[] = 'broadcast';
-        }
-
-        return $channels;
-    }
-
     /**
      * @throws ContainerExceptionInterface
      * @throws NotFoundExceptionInterface
@@ -79,10 +34,5 @@ class RoomRequestNotification extends Notification implements ShouldBroadcast
                     'pageTitle' => $pageTitle,
                 ]
             );
-    }
-
-    public function toArray(): stdClass
-    {
-        return $this->notificationData;
     }
 }

--- a/artwork/Modules/Shift/Notifications/ShiftNotification.php
+++ b/artwork/Modules/Shift/Notifications/ShiftNotification.php
@@ -2,61 +2,15 @@
 
 namespace Artwork\Modules\Shift\Notifications;
 
+use Artwork\Core\Notifications\BaseNotification;
 use Artwork\Modules\GeneralSettings\Models\GeneralSettings;
-use Illuminate\Bus\Queueable;
 use Illuminate\Config\Repository;
-use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
-use Illuminate\Notifications\Messages\BroadcastMessage;
 use Illuminate\Notifications\Messages\MailMessage;
-use Illuminate\Notifications\Notification;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\NotFoundExceptionInterface;
-use stdClass;
 
-class ShiftNotification extends Notification implements ShouldBroadcast
+class ShiftNotification extends BaseNotification
 {
-    use Queueable;
-
-    protected ?stdClass $notificationData = null;
-
-    protected array $broadcastMessage = [];
-
-    public function __construct($notificationData, $broadcastMessage = [])
-    {
-        $this->notificationData = $notificationData;
-        $this->broadcastMessage = $broadcastMessage;
-    }
-
-    public function toBroadcast(): BroadcastMessage
-    {
-        return new BroadcastMessage([
-            'message' => $this->broadcastMessage
-        ]);
-    }
-
-    /**
-     * @return string[]
-     */
-    public function via($user): array
-    {
-        $channels = ['database'];
-
-        $typeSettings = $user->notificationSettings()
-            ->where('type', $this->notificationData->type)
-            ->first();
-
-//        if ($typeSettings?->enabled_email) {
-//            $channels[] = 'mail';
-//        }
-
-
-        if ($typeSettings?->enabled_push && !empty($this->broadcastMessage)) {
-            $channels[] = 'broadcast';
-        }
-
-        return $channels;
-    }
-
     /**
      * @throws ContainerExceptionInterface
      * @throws NotFoundExceptionInterface
@@ -80,10 +34,5 @@ class ShiftNotification extends Notification implements ShouldBroadcast
                     'pageTitle' => $pageTitle,
                 ]
             );
-    }
-
-    public function toArray(): stdClass
-    {
-        return $this->notificationData;
     }
 }

--- a/artwork/Modules/Task/Notifications/DeadlineNotification.php
+++ b/artwork/Modules/Task/Notifications/DeadlineNotification.php
@@ -2,60 +2,15 @@
 
 namespace Artwork\Modules\Task\Notifications;
 
+use Artwork\Core\Notifications\BaseNotification;
 use Artwork\Modules\GeneralSettings\Models\GeneralSettings;
-use Illuminate\Bus\Queueable;
 use Illuminate\Config\Repository;
-use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
-use Illuminate\Notifications\Messages\BroadcastMessage;
 use Illuminate\Notifications\Messages\MailMessage;
-use Illuminate\Notifications\Notification;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\NotFoundExceptionInterface;
-use stdClass;
 
-class DeadlineNotification extends Notification implements ShouldBroadcast
+class DeadlineNotification extends BaseNotification
 {
-    use Queueable;
-
-    protected ?stdClass $notificationData = null;
-
-    protected array $broadcastMessage = [];
-
-    public function __construct($notificationData, array $broadcastMessage = [])
-    {
-        $this->notificationData = $notificationData;
-        $this->broadcastMessage = $broadcastMessage;
-    }
-
-    public function toBroadcast(): BroadcastMessage
-    {
-        return new BroadcastMessage([
-            'message' => $this->broadcastMessage
-        ]);
-    }
-
-    /**
-     * @return string[]
-     */
-    public function via($user): array
-    {
-        $channels = ['database'];
-
-        $typeSettings = $user->notificationSettings()
-            ->where('type', $this->notificationData->type)
-            ->first();
-
-//        if ($typeSettings?->enabled_email) {
-//            $channels[] = 'mail';
-//        }
-
-        if ($typeSettings?->enabled_push && !empty($this->broadcastMessage)) {
-            $channels[] = 'broadcast';
-        }
-
-        return $channels;
-    }
-
     /**
      * @throws ContainerExceptionInterface
      * @throws NotFoundExceptionInterface
@@ -79,10 +34,5 @@ class DeadlineNotification extends Notification implements ShouldBroadcast
                     'pageTitle' => $pageTitle,
                 ]
             );
-    }
-
-    public function toArray(): stdClass
-    {
-        return $this->notificationData;
     }
 }

--- a/artwork/Modules/Task/Notifications/TaskNotification.php
+++ b/artwork/Modules/Task/Notifications/TaskNotification.php
@@ -2,60 +2,15 @@
 
 namespace Artwork\Modules\Task\Notifications;
 
+use Artwork\Core\Notifications\BaseNotification;
 use Artwork\Modules\GeneralSettings\Models\GeneralSettings;
-use Illuminate\Bus\Queueable;
 use Illuminate\Config\Repository;
-use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
-use Illuminate\Notifications\Messages\BroadcastMessage;
 use Illuminate\Notifications\Messages\MailMessage;
-use Illuminate\Notifications\Notification;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\NotFoundExceptionInterface;
-use stdClass;
 
-class TaskNotification extends Notification implements ShouldBroadcast
+class TaskNotification extends BaseNotification
 {
-    use Queueable;
-
-    protected ?stdClass $notificationData = null;
-
-    protected array $broadcastMessage = [];
-
-    public function __construct($notificationData, $broadcastMessage = [])
-    {
-        $this->notificationData = $notificationData;
-        $this->broadcastMessage = $broadcastMessage;
-    }
-
-    public function toBroadcast(): BroadcastMessage
-    {
-        return new BroadcastMessage([
-            'message' => $this->broadcastMessage
-        ]);
-    }
-
-    /**
-     * @return string[]
-     */
-    public function via($user): array
-    {
-        $channels = ['database'];
-
-        $typeSettings = $user->notificationSettings()
-            ->where('type', $this->notificationData->type)
-            ->first();
-
-//        if ($typeSettings?->enabled_email) {
-//            $channels[] = 'mail';
-//        }
-
-        if ($typeSettings?->enabled_push && !empty($this->broadcastMessage)) {
-            $channels[] = 'broadcast';
-        }
-
-        return $channels;
-    }
-
     /**
      * @throws ContainerExceptionInterface
      * @throws NotFoundExceptionInterface
@@ -79,10 +34,5 @@ class TaskNotification extends Notification implements ShouldBroadcast
                     'pageTitle' => $pageTitle,
                 ]
             );
-    }
-
-    public function toArray(): stdClass
-    {
-        return $this->notificationData;
     }
 }


### PR DESCRIPTION
- add immediately frequency in notifications email settings
- skip immedieately in SendNotificationsEmailSummariesCommand
- re-enable immediate email in notification classes
- refactor/cleanup/boyscout notifications, create BaseNotification, centralized handling, derived classes only implement business logic