### PR TITLE
fix time problem

### DIFF
--- a/artwork/Modules/Event/Services/EventService.php
+++ b/artwork/Modules/Event/Services/EventService.php
@@ -1195,6 +1195,46 @@ readonly class EventService
         return [$day, $endDay, $allDay];
     }
 
+    /**
+     * @param Carbon $day
+     * @param string|null $startTime
+     * @param string|null $endTime
+     * @return array{Carbon, Carbon, bool}
+     */
+    public function processEventTimesForTimeline(Carbon $day, ?string $startTime, ?string $endTime): array
+    {
+        $endDay = clone $day;
+        $allDay = false;
+
+        if (!$startTime && !$endTime) {
+            $allDay = true;
+            $day->startOfDay();
+            $endDay->endOfDay();
+        } else {
+            $startTime = $startTime ? Carbon::parse($startTime) : null;
+            $endTime = $endTime ? Carbon::parse($endTime) : null;
+
+            // Start- oder Endzeitpunkt fehlen
+            if (!$startTime && $endTime) {
+                $startTime = clone $endTime;
+            } elseif (!$endTime && $startTime) {
+                $endTime = clone $startTime;
+            } elseif ($startTime && $endTime) {
+                if ($endTime->lt($startTime) || $endTime->eq($startTime)) {
+                    $endDay->addDay();
+                }
+            }
+            if ($startTime) {
+                $day->setTimeFromTimeString($startTime->toTimeString());
+            }
+            if ($endTime) {
+                $endDay->setTimeFromTimeString($endTime->toTimeString());
+            }
+        }
+
+        return [$day, $endDay, $allDay];
+    }
+
 
     public function createBulkEvent(
         array $event,

--- a/artwork/Modules/Event/Services/EventTimelineService.php
+++ b/artwork/Modules/Event/Services/EventTimelineService.php
@@ -94,7 +94,7 @@ readonly class EventTimelineService
      */
     private function createTimeline(Event $event, array $timeline): void
     {
-        [$startTime, $endTime, $allDay] = $this->eventService->processEventTimes(
+        [$startTime, $endTime, $allDay] = $this->eventService->processEventTimesForTimeline(
             Carbon::parse($event->start_time),
             $timeline['start'] ?? null,
             $timeline['end'] ?? null


### PR DESCRIPTION
This pull request introduces a new method to handle event times specifically for timelines and updates the existing method calls to use this new functionality. The changes are focused on improving the handling of event times within the `EventService` and `EventTimelineService` classes.

Key changes include:

### New Method Addition:
* [`artwork/Modules/Event/Services/EventService.php`](diffhunk://#diff-7158881782a6445e07413e19698961fb28d16577e7434e2133abbfcf0260e691R1198-R1237): Added a new method `processEventTimesForTimeline` to handle event times specifically for timelines. This method processes start and end times, and determines if the event is an all-day event.

### Method Call Update:
* [`artwork/Modules/Event/Services/EventTimelineService.php`](diffhunk://#diff-d36248f6674c87798d18e2c46af5facd5e18241cebf6f89e8f471312e02d0a4aL97-R97): Updated the `createTimeline` method to use the newly added `processEventTimesForTimeline` method instead of the original `processEventTimes` method.