### PR TITLE
fix shiftplan and fix edit notes in shifttab

### DIFF
--- a/app/Http/Controllers/ShiftController.php
+++ b/app/Http/Controllers/ShiftController.php
@@ -6,6 +6,7 @@ use Artwork\Modules\Availability\Models\AvailabilitiesConflict;
 use Artwork\Modules\Availability\Services\AvailabilityConflictService;
 use Artwork\Modules\Change\Services\ChangeService;
 use Artwork\Modules\Event\Models\Event;
+use Artwork\Modules\Event\Services\EventService;
 use Artwork\Modules\Event\Services\EventTimelineService;
 use Artwork\Modules\Freelancer\Models\Freelancer;
 use Artwork\Modules\IndividualTimes\Services\IndividualTimeService;
@@ -56,7 +57,7 @@ class ShiftController extends Controller
         private readonly ShiftPlanCommentService $shiftPlanCommentService,
         private readonly VacationService $vacationService,
         private readonly EventTimelineService $eventTimelineService,
-        private readonly UserService $userService
+        private readonly EventService $eventService,
     ) {
     }
 
@@ -68,6 +69,7 @@ class ShiftController extends Controller
         Event $event,
         ShiftsQualificationsService $shiftsQualificationsService
     ): void {
+
         $shift = $this->shiftService->createAutomatic(
             event: $event,
             craftId: $request->craft_id,

--- a/artwork/Modules/Shift/Services/ShiftService.php
+++ b/artwork/Modules/Shift/Services/ShiftService.php
@@ -106,8 +106,8 @@ class ShiftService
         $shift = new Shift();
         $shift->start_date = $this->convertStartEndTime($data, $event)->start;
         $shift->end_date = $this->convertStartEndTime($data, $event)->end;
-        $shift->start = $data['start'];
-        $shift->end = $data['end'];
+        $shift->start = Carbon::parse($data['start'])->format('H:i');
+        $shift->end =  Carbon::parse($data['end'])->format('H:i');
         $shift->break_minutes = $data['break_minutes'];
         $shift->description = $data['description'];
         $shift->event()->associate($event);
@@ -138,8 +138,8 @@ class ShiftService
         $shift = new Shift();
         $shift->start_date = $day;
         $shift->end_date = $day;
-        $shift->start = $data['start'];
-        $shift->end = $data['end'];
+        $shift->start = Carbon::parse($data['start'])->format('H:i');
+        $shift->end =  Carbon::parse($data['end'])->format('H:i');
         $shift->break_minutes = $data['break_minutes'];
         $shift->description = $data['description'];
         $shift->craft()->associate($craftId);

--- a/resources/js/Layouts/Components/ShiftNoteComponent.vue
+++ b/resources/js/Layouts/Components/ShiftNoteComponent.vue
@@ -1,14 +1,14 @@
 <template>
-    <div class="my-2" @click="showTextField ? updateDescription : openTextField" v-if="!showTextField && $can('can plan shifts') || hasAdminRole()">
-        <div v-if="shift.description?.length === 0 || shift.description === null">
-            <IconNote class="w-4 h-4 cursor pointer text-artwork-buttons-context" />
+    <div class="my-2 px-1" @click="openTextField" v-if="!showTextField && $can('can plan shifts') || hasAdminRole()">
+        <div v-if="shift.description?.length === 0 || shift.description === null && !showTextField">
+            <IconNote class="w-4 h-4 cursor-pointer text-artwork-buttons-context" />
         </div>
-        <p v-else-if="!showTextField" class="text-xs">
+        <p v-else-if="!showTextField" class="text-xs cursor-pointer">
             {{ cutDescription }}
         </p>
     </div>
     <div v-if="showTextField">
-        <div class="cursor-pointer">
+        <div class="cursor-pointer px-1">
             <textarea ref="descriptionField" v-model="shiftDescription.description" class="w-full h-20 p-1 text-sm border-artwork-buttons-context/30 rounded-lg" maxlength="250" @focusout="updateDescription" />
             <div class="text-xs text-end text-artwork-buttons-context">
                 {{ shiftDescription.description.length }} / 250

--- a/resources/js/Layouts/Components/ShiftPlanComponents/ShiftDropElement.vue
+++ b/resources/js/Layouts/Components/ShiftPlanComponents/ShiftDropElement.vue
@@ -1,9 +1,11 @@
 <template>
-    <div class="w-full cursor-pointer group/shift">
+    <div class="w-full group/shift bg-backgroundGray hover:bg-gray-50 duration-300 ease-in-out cursor-pointer">
         <div :class="[!highlightMode || !isIdHighlighted(highlightedId, highlightedType) ? 'opacity-30 px-1' : 'bg-pink-500 !text-white px-1', multiEditMode ?'text-[10px]' : '']"
              class="flex items-center xsLight text-shiftText subpixel-antialiased"
              @dragover="onDragOver"
-             @drop="onDrop">
+             @drop="onDrop"
+            @click="handleClickEvent"
+        >
             <div v-if="multiEditMode && userForMultiEdit && checkIfUserIsInCraft">
                 <input v-model="userForMultiEdit.shift_ids"
                        @change="(e) => handleShiftAndEventForMultiEdit(e.target.checked, shift, event)"
@@ -25,10 +27,6 @@
                     <div v-if="computedUsedWorkerCount >= computedMaxWorkerCount">
                         <IconCheck stroke-width="1.5" class="h-5 w-5 flex text-success" aria-hidden="true"/>
                     </div>
-                </div>
-
-                <div class="hidden group-hover/shift:block" v-if="$can('can plan shifts') || this.hasAdminRole()">
-                    <component is="IconEdit" class="h-5 w-5 " stroke-width="1.5" @click="$emit('clickOnEdit', shift)"/>
                 </div>
             </div>
         </div>
@@ -213,6 +211,11 @@ export default defineComponent({
         },
     },
     methods: {
+        handleClickEvent(){
+            if ( this.$can('can plan shifts') || this.hasAdminRole() ){
+                this.$emit('clickOnEdit', this.shift)
+            }
+        },
         usePage,
         onDragOver(event) {
             event.preventDefault();

--- a/resources/js/Pages/Shifts/ShiftPlan.vue
+++ b/resources/js/Pages/Shifts/ShiftPlan.vue
@@ -135,7 +135,7 @@
                                         <div class="bg-backgroundGray2 h-full mb-3" style="width: 37px;" v-if="day.is_extra_row">
                                         </div>
                                         <!-- Build in v-if="this.currentDaysInView.has(day.full_day)" when observer fixed -->
-                                        <div v-else style="width: 200px" class="cell group " :class="$page.props.user.calendar_settings.expand_days ? '' : 'max-h-28 h-28 overflow-y-auto'">
+                                        <div v-else style="width: 200px" class="cell group " :class="$page.props.user.calendar_settings.expand_days ? 'min-h-12' : 'max-h-28 h-28 overflow-y-auto'">
                                             <div v-for="event in room.content[day.full_day].events" class="mb-1">
                                                 <SingleShiftPlanEvent
                                                     v-if="checkIfEventHasShiftsToDisplay(event)"
@@ -182,7 +182,7 @@
                                                 </div>
                                             </div>
                                             <div v-if="!multiEditModeCalendar"
-                                                 class="invisible group-hover:visible absolute bottom-2 left-2 cursor-pointer rounded-full p-0.5 bg-white shadow-md border-2 border-dashed border-artwork-buttons-create"
+                                                 class="invisible group-hover:visible absolute top-2 right-2 cursor-pointer rounded-full p-0.5 bg-white shadow-md border-2 border-dashed border-artwork-buttons-create"
                                                  @click="openAddShiftForRoomAndDay(day.without_format, room.roomId)">
                                                 <ToolTipComponent
                                                     :tooltip-text="$t('Add shift')"


### PR DESCRIPTION
This pull request includes several changes to the `ShiftController` and `ShiftService` classes, as well as multiple Vue components. The most important changes focus on adding a new dependency, modifying shift creation logic, and improving the user interface for shift planning.

### Dependency Management:
* Added `EventService` dependency to `ShiftController` and updated the constructor to include this service. (`app/Http/Controllers/ShiftController.php`) [[1]](diffhunk://#diff-3d46fafb0a19db4743b3bac7cdffc72bbd5cc32eeb82b432356886b796fb5129R9) [[2]](diffhunk://#diff-3d46fafb0a19db4743b3bac7cdffc72bbd5cc32eeb82b432356886b796fb5129L59-R60)

### Shift Creation Logic:
* Modified `createAutomatic` and `createShiftWithoutEventAutomatic` methods in `ShiftService` to format `start` and `end` times using `Carbon::parse`. (`artwork/Modules/Shift/Services/ShiftService.php`) [[1]](diffhunk://#diff-357aac2467673bf86f58ed3766c1aea7ecd0c33e7f815097d2e818988ed854e2L109-R110) [[2]](diffhunk://#diff-357aac2467673bf86f58ed3766c1aea7ecd0c33e7f815097d2e818988ed854e2L141-R142)

### User Interface Improvements:
* Updated `ShiftNoteComponent.vue` to improve the click behavior and visual feedback for shift descriptions. (`resources/js/Layouts/Components/ShiftNoteComponent.vue`)
* Enhanced `ShiftDropElement.vue` by adding a click event handler and adjusting the hover behavior for better usability. (`resources/js/Layouts/Components/ShiftPlanComponents/ShiftDropElement.vue`) [[1]](diffhunk://#diff-5153bf2b1b9f161491dab5578fa503f81edaf0a0622c5819a3cff46ed8eba9e3L2-R8) [[2]](diffhunk://#diff-5153bf2b1b9f161491dab5578fa503f81edaf0a0622c5819a3cff46ed8eba9e3L29-L32) [[3]](diffhunk://#diff-5153bf2b1b9f161491dab5578fa503f81edaf0a0622c5819a3cff46ed8eba9e3R214-R218)
* Adjusted the layout and visibility of elements in `ShiftPlan.vue` to improve the user experience when interacting with shift plans. (`resources/js/Pages/Shifts/ShiftPlan.vue`) [[1]](diffhunk://#diff-69558a693ec3368b76c8655d2d91ba1e5208b8864d8e0bc0b9802796653a8aafL138-R138) [[2]](diffhunk://#diff-69558a693ec3368b76c8655d2d91ba1e5208b8864d8e0bc0b9802796653a8aafL185-R185)