### PR TITLE
refactor own shiftplan functions

### DIFF
--- a/artwork/Modules/Freelancer/Services/FreelancerService.php
+++ b/artwork/Modules/Freelancer/Services/FreelancerService.php
@@ -140,8 +140,9 @@ readonly class FreelancerService
         $startOfWeek = $startDate->copy()->startOfWeek();
         $endOfWeek = $endDate->copy()->endOfWeek();
 
-        $daysWithData = $eventService->getDaysWithEventsWhereFreelancerHasShiftsWithTotalPlannedWorkingHours(
+        $daysWithData = $eventService->getDaysWithEventsAndTotalPlannedWorkingHours(
             $freelancer->id,
+            'freelancer',
             $startOfWeek,
             $endOfWeek
         );

--- a/artwork/Modules/ServiceProvider/Services/ServiceProviderService.php
+++ b/artwork/Modules/ServiceProvider/Services/ServiceProviderService.php
@@ -108,8 +108,9 @@ readonly class ServiceProviderService
         $startOfWeek = $startDate->copy()->startOfWeek();
         $endOfWeek = $endDate->copy()->endOfWeek();
 
-        $daysWithData = $eventService->getDaysWithEventsWhereServiceProviderHasShiftsWithTotalPlannedWorkingHours(
+        $daysWithData = $eventService->getDaysWithEventsAndTotalPlannedWorkingHours(
             $serviceProvider->id,
+            'service_provider',
             $startOfWeek,
             $endOfWeek
         );
@@ -125,7 +126,8 @@ readonly class ServiceProviderService
                                 return [
                                     'inRequestedTimeSpan' => in_array(
                                         $date->format('d.m.Y'),
-                                        $requestedPeriod
+                                        $requestedPeriod,
+                                        true
                                     ),
                                     'full_day' => $date->format('d.m.Y'),
                                     'day' => $date->format('d.m.'),

--- a/artwork/Modules/User/Services/UserService.php
+++ b/artwork/Modules/User/Services/UserService.php
@@ -170,8 +170,9 @@ class UserService
         $startOfWeek = $requestedStartDate->copy()->startOfWeek();
         $endOfWeek = $requestedEndDate->copy()->endOfWeek();
 
-        $daysWithData = $eventService->getDaysWithEventsWhereUserHasShiftsWithTotalPlannedWorkingHours(
+        $daysWithData = $eventService->getDaysWithEventsAndTotalPlannedWorkingHours(
             $user->id,
+            'users',
             $startOfWeek,
             $endOfWeek
         );

--- a/resources/js/Components/Calendar/BaseCalendar.vue
+++ b/resources/js/Components/Calendar/BaseCalendar.vue
@@ -51,7 +51,7 @@
                                     </div>
                                     <div :style="{ minWidth: zoom_factor * 212 + 'px', maxWidth: zoom_factor * 212 + 'px', height: usePage().props.user.calendar_settings.expand_days ? '' : zoom_factor * 115 + 'px' }"
                                          :class="[zoom_factor > 0.4 ? 'cell' : 'overflow-hidden']"
-                                         class="group/container border-t-2 border-gray-400 border-dashed" :id="'scroll_container-' + day.without_format">
+                                         class="group/container border-t border-gray-300 border-dashed" :id="'scroll_container-' + day.without_format">
                                         <div v-if="composedCurrentDaysInViewRef.has(day.full_day)" v-for="(event, index) in room.content[day.full_day].events">
                                             <div class="py-0.5" :key="event.id" :id="'event_scroll-' + index + '-day-' + day.without_format">
                                                 <AsyncSingleEventInCalendar


### PR DESCRIPTION
This pull request includes several changes to improve the consistency and functionality of the event services and the user interface. The most important changes include updates to method names for clarity, enhancements to function parameters for strict comparison, and adjustments to the calendar component styling.

Updates to method names and parameters:

* [`artwork/Modules/Freelancer/Services/FreelancerService.php`](diffhunk://#diff-2cc2910753cdf30a636fa22ce4e60bf8fbaf1b441605d729977e0966488e5e74L143-R145): Renamed method `getDaysWithEventsWhereFreelancerHasShiftsWithTotalPlannedWorkingHours` to `getDaysWithEventsAndTotalPlannedWorkingHours` and added the parameter `'freelancer'`.
* [`artwork/Modules/ServiceProvider/Services/ServiceProviderService.php`](diffhunk://#diff-5d34d0eb5deb4176a6ab2e98d26c9f91f6312a4e765da0abb0f4a24d216dd70fL111-R113): Renamed method `getDaysWithEventsWhereServiceProviderHasShiftsWithTotalPlannedWorkingHours` to `getDaysWithEventsAndTotalPlannedWorkingHours` and added the parameter `'service_provider'`.
* [`artwork/Modules/User/Services/UserService.php`](diffhunk://#diff-d82bdd95ca5c6e56b7b1e59e6609c5490504fb6e7ea5542207598dd424f60b5bL173-R175): Renamed method `getDaysWithEventsWhereUserHasShiftsWithTotalPlannedWorkingHours` to `getDaysWithEventsAndTotalPlannedWorkingHours` and added the parameter `'users'`.

Enhancements to function parameters:

* [`artwork/Modules/ServiceProvider/Services/ServiceProviderService.php`](diffhunk://#diff-5d34d0eb5deb4176a6ab2e98d26c9f91f6312a4e765da0abb0f4a24d216dd70fL128-R130): Added `true` as the third parameter to `in_array` for strict comparison in the function that checks if the date is in the requested period.

Adjustments to calendar component styling:

* [`resources/js/Components/Calendar/BaseCalendar.vue`](diffhunk://#diff-563316e3eb1a4bd64492a4f773e5575fa2fc143331cf6637a758c05d57aada0cL54-R54): Modified the class and border styles for better visual consistency in the calendar component.