### PR TITLE
Add event create permission

### DIFF
--- a/artwork/Core/Console/Commands/UpdatePermissionsCommand.php
+++ b/artwork/Core/Console/Commands/UpdatePermissionsCommand.php
@@ -81,6 +81,15 @@ class UpdatePermissionsCommand extends Command
                 'tooltipText' => 'Darf private Kontaktdaten von Nutzer*innen einsehen',
                 'tooltipKey' => "Can view private contact details of users",
                 'checked' => false
+            ],
+            [
+                'name' => PermissionEnum::CREATE_EVENTS_WITHOUT_REQUEST->value,
+                'name_de' => "Termine fest planen",
+                'translation_key' => "Schedule events without request",
+                'group' => 'Room bookings',
+                'tooltipText' => 'Ein User mit diesem Recht darf Termine ohne Anfrage direkt fest planen in allen Räumen',
+                'tooltipKey' => 'A user with this permission can schedule events directly without a request in all rooms',
+                'checked' => false
             ]
         ];
 

--- a/artwork/Modules/Permission/Enums/PermissionEnum.php
+++ b/artwork/Modules/Permission/Enums/PermissionEnum.php
@@ -12,6 +12,7 @@ enum PermissionEnum : string
     case PROJECT_BUDGET_VERIFIED_ADD_REMOVE = 'can add and remove verified states';
     case PROJECT_BUDGET_SEE_DOCS_CONTRACTS = 'can see, edit and delete project contracts and docs';
     case EVENT_REQUEST = 'request room occupancy';
+    case CREATE_EVENTS_WITHOUT_REQUEST = 'create events without request';
     case ROOM_UPDATE = 'create, delete and update rooms';
     case CONTRACT_EDIT_UPLOAD = 'view edit upload contracts';
     case MONEY_SOURCE_EDIT_VIEW_ADD = 'view edit add money_sources';

--- a/artwork/Modules/Setup/DataProvider/BaseDataProvider.php
+++ b/artwork/Modules/Setup/DataProvider/BaseDataProvider.php
@@ -76,6 +76,15 @@ class BaseDataProvider implements RoleAndPermissionDataProvider
                 'checked' => false
             ],
             [
+                'name' => PermissionEnum::CREATE_EVENTS_WITHOUT_REQUEST->value,
+                'name_de' => "Termine fest planen",
+                'translation_key' => "Schedule events without request",
+                'group' => 'Room bookings',
+                'tooltipText' => 'Ein User mit diesem Recht darf Termine ohne Anfrage direkt fest planen in allen Räumen',
+                'tooltipKey' => 'A user with this permission can schedule events directly without a request in all rooms',
+                'checked' => false
+            ],
+            [
                 'name' => PermissionEnum::CONTRACT_SEE_DOWNLOAD->value,
                 'name_de' => "Darf Vertragsbausteine einsehen & runterladen",
                 'translation_key' => "Allowed to view & download contract components",

--- a/lang/de.json
+++ b/lang/de.json
@@ -2306,5 +2306,7 @@
     "Select all": "Alle auswählen",
     "Select an icon from {0} different icons.": "Wähle ein Icon aus {0} verschiedenen Icons aus.",
     "Universal Shift": "Universelle Schicht",
-    "Select an icon": "Icon auswählen"
+    "Select an icon": "Icon auswählen",
+    "Schedule events without request": "Termine ohne Anfrage planen",
+    "A user with this permission can schedule events directly without a request in all rooms": "Ein Nutzer mit dieser Berechtigung kann direkt Termine ohne Anfrage in allen Räumen planen"
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -2305,5 +2305,7 @@
     "Select all": "Select all",
     "Select an icon from {0} different icons.": "Select an icon from {0} different icons.",
     "Universal Shift": "Universal Shift",
-    "Select an icon": "Select an icon"
+    "Select an icon": "Select an icon",
+    "Schedule events without request": "Schedule events without request",
+    "A user with this permission can schedule events directly without a request in all rooms": "A user with this permission can schedule events directly without a request in all rooms"
 }

--- a/resources/js/Layouts/Components/EventComponent.vue
+++ b/resources/js/Layouts/Components/EventComponent.vue
@@ -603,8 +603,7 @@
             </div>
 
             <div v-if="canEdit">
-                <div class="flex justify-center w-full py-4"
-                     v-if="(isAdmin || selectedRoom?.everyone_can_book || roomAdminIds.includes(this.$page.props.user.id))">
+                <div class="flex justify-center w-full py-4" v-if="(isAdmin || selectedRoom?.everyone_can_book || roomAdminIds.includes(this.$page.props.user.id) || $can('create events without request'))">
                     <FormButton
                         :disabled="this.selectedRoom === null || !submit  || endDate > seriesEndDate || series && !seriesEndDate || (this.accept === false && this.optionAccept === false && adminComment === '')"
                         @click="updateOrCreateEvent()"


### PR DESCRIPTION
This pull request introduces a new permission for scheduling events without requests and updates related files accordingly. The most important changes include adding the new permission to the `PermissionEnum` enum, updating permission handling in various files, and adding translations for the new permission.

### New Permission Addition and Handling:

* [`artwork/Modules/Permission/Enums/PermissionEnum.php`](diffhunk://#diff-dcfd58fbdc6c73ebe4bc2e45690a13218466cecea034029bf98aa7557cfee52eR15): Added the new permission `CREATE_EVENTS_WITHOUT_REQUEST` to the `PermissionEnum` enum.
* [`artwork/Core/Console/Commands/UpdatePermissionsCommand.php`](diffhunk://#diff-254b2725602caa2b3cea0f00c9af41de1ddcda59e05751d237857420080f859fR84-R92): Included the new permission in the list of permissions with its details such as name, translation key, group, and tooltip text.
* [`artwork/Modules/Setup/DataProvider/BaseDataProvider.php`](diffhunk://#diff-4c7798b3dfcda409c7d6d10c6236bc9718a59a2891a8ea65cfc016c503312d85R78-R86): Added the new permission to the permissions array with its respective details.

### Translation Updates:

* [`lang/de.json`](diffhunk://#diff-b856eeca8165aed4012d1d98ca6e927f20366c9c1272932ad9d8004358c1f38dL2309-R2311): Added German translations for the new permission and its tooltip.
* [`lang/en.json`](diffhunk://#diff-1d56632a2d162f99c901e53b79a6224e984c14501bca3188a85dbb4b4c5e6da1L2308-R2310): Added English translations for the new permission and its tooltip.

### Frontend Update:

* [`resources/js/Layouts/Components/EventComponent.vue`](diffhunk://#diff-3d47a880989dddc7caf02d74e6c640491f1ec24975c6591bcefefaa71b470513L606-R606): Updated the event component to check for the new permission when determining if a user can schedule events without requests.