### PR TITLE
Make Tab default

### DIFF
--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -251,7 +251,7 @@ class ProjectController extends Controller
             /** @var Project $project */
             $projectData = new stdClass(); // needed for the ProjectShowHeaderComponent
             $projectData->id = $project->id;
-            $projectData->firstTabId = $this->projectTabService->getFirstProjectTabId();
+            $projectData->firstTabId = $this->projectTabService->getDefaultOrFirstProjectTabId();
             $projectData->project_managers = $project->managerUsers;
             $projectData->write_auth = $project->writeUsers;
             $projectData->delete_permission_users = $project->delete_permission_users;
@@ -324,7 +324,7 @@ class ProjectController extends Controller
             /** @var Project $project */
             $projectData = new stdClass(); // needed for the ProjectShowHeaderComponent
             $projectData->id = $project->id;
-            $projectData->firstTabId = $this->projectTabService->getFirstProjectTabId();
+            $projectData->firstTabId = $this->projectTabService->getDefaultOrFirstProjectTab();
             $projectData->project_managers = $project->managerUsers;
             $projectData->write_auth = $project->writeUsers;
             $projectData->delete_permission_users = $project->delete_permission_users;
@@ -402,7 +402,7 @@ class ProjectController extends Controller
             'components' => $components,
             'pinnedProjects' => $pinnedProjectsComponents,
             'pinnedProjectsAll' => $pinnedProjects,
-            'first_project_tab_id' => $this->projectTabService->getFirstProjectTabId(),
+            'first_project_tab_id' => $this->projectTabService->getDefaultOrFirstProjectTab(),
             'states' => $this->projectStateService->getAll(),
             'projectGroups' => $this->projectService->getProjectGroups(),
             'categories' => $this->categoryService->getAll(),

--- a/app/Http/Controllers/ProjectTabController.php
+++ b/app/Http/Controllers/ProjectTabController.php
@@ -121,4 +121,10 @@ class ProjectTabController extends Controller
             'scope' => $request->input('scope'),
         ]);
     }
+
+    public function updateDefault(ProjectTab $projectTab): void
+    {
+        ProjectTab::where('default', true)->update(['default' => false]);
+        $projectTab->update(['default' => true]);
+    }
 }

--- a/artwork/Modules/ProjectTab/Models/ProjectTab.php
+++ b/artwork/Modules/ProjectTab/Models/ProjectTab.php
@@ -24,6 +24,11 @@ class ProjectTab extends Model
     protected $fillable = [
         'name',
         'order',
+        'default'
+    ];
+
+    protected $casts = [
+        'default' => 'boolean'
     ];
 
     protected $appends = ['hasSidebarTabs'];

--- a/artwork/Modules/ProjectTab/Repositories/ProjectTabRepository.php
+++ b/artwork/Modules/ProjectTab/Repositories/ProjectTabRepository.php
@@ -37,4 +37,11 @@ class ProjectTabRepository extends BaseRepository
     {
         return ProjectTab::find($id);
     }
+
+    public function getDefaultOrFirstProjectTab(): ?ProjectTab
+    {
+        return ProjectTab::query()
+            ->where('default', true)
+            ->first() ?? $this->findFirstProjectTab();
+    }
 }

--- a/artwork/Modules/ProjectTab/Services/ProjectTabService.php
+++ b/artwork/Modules/ProjectTab/Services/ProjectTabService.php
@@ -43,6 +43,16 @@ class ProjectTabService implements ServiceWithArrayCache
         return $this->projectTabRepository->findFirstProjectTab();
     }
 
+    public function getDefaultOrFirstProjectTab(): ProjectTab
+    {
+        return $this->projectTabRepository->getDefaultOrFirstProjectTab();
+    }
+
+    public function getDefaultOrFirstProjectTabId(): int
+    {
+        return $this->getDefaultOrFirstProjectTab()->getAttribute('id');
+    }
+
     public function getFirstProjectTabId(): int
     {
         return $this->findFirstProjectTab()->getAttribute('id');
@@ -70,7 +80,7 @@ class ProjectTabService implements ServiceWithArrayCache
     public function getFirstProjectTabWithTypeIdOrFirstProjectTabId(ProjectTabComponentEnum $type): int
     {
         return $this->findFirstProjectTabWithType($type)?->getAttribute('id') ??
-            $this->getFirstProjectTabId();
+            $this->getDefaultOrFirstProjectTabId();
     }
 
     public function getShiftTab(

--- a/database/migrations/2025_02_07_134749_add_default_to_project_tabs.php
+++ b/database/migrations/2025_02_07_134749_add_default_to_project_tabs.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('project_tabs', function (Blueprint $table) {
+            $table->boolean('default')->default(false)->after('name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('project_tabs', function (Blueprint $table) {
+            $table->dropColumn('default');
+        });
+    }
+};

--- a/lang/de.json
+++ b/lang/de.json
@@ -2306,5 +2306,6 @@
     "Select all": "Alle auswählen",
     "Select an icon from {0} different icons.": "Wähle ein Icon aus {0} verschiedenen Icons aus.",
     "Universal Shift": "Universelle Schicht",
-    "Select an icon": "Icon auswählen"
+    "Select an icon": "Icon auswählen",
+    "Should this tab be set as the default tab?": "Soll dieser Tab als Standardtab festgelegt werden?"
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -2305,5 +2305,6 @@
     "Select all": "Select all",
     "Select an icon from {0} different icons.": "Select an icon from {0} different icons.",
     "Universal Shift": "Universal Shift",
-    "Select an icon": "Select an icon"
+    "Select an icon": "Select an icon",
+    "Should this tab be set as the default tab?": "Should this tab be set as the default tab?"
 }

--- a/resources/js/Pages/Settings/Components/SingleTabComponent.vue
+++ b/resources/js/Pages/Settings/Components/SingleTabComponent.vue
@@ -7,26 +7,47 @@
                 <IconChevronDown v-if="tabClosed" class="h-5 w-5 text-gray-600"/>
                 <IconChevronUp v-else class="h-5 w-5 text-gray-600"/>
             </div>
-            <BaseMenu has-no-offset>
-                <MenuItem v-slot="{ active }">
-                    <a href="#" @click="editTab"
-                       :class="[active ? 'bg-artwork-navigation-color/10 text-white' : 'text-secondary', 'group flex items-center px-4 py-2 text-sm subpixel-antialiased']">
-                        <IconEdit stroke-width="1.5"
-                                  class="mr-3 h-5 w-5 text-primaryText group-hover:text-white"
-                                  aria-hidden="true"/>
-                        {{ $t('Edit') }}
-                    </a>
-                </MenuItem>
-                <MenuItem v-slot="{ active }">
-                    <a href="#" @click="removeTab"
-                       :class="[active ? 'bg-artwork-navigation-color/10 text-white' : 'text-secondary', 'group flex items-center px-4 py-2 text-sm subpixel-antialiased']">
-                        <IconTrash stroke-width="1.5"
-                                   class="mr-3 h-5 w-5 text-primaryText group-hover:text-white"
-                                   aria-hidden="true"/>
-                        {{ $t('Delete') }}
-                    </a>
-                </MenuItem>
-            </BaseMenu>
+            <div class="flex items-center gap-x-2">
+                <div class="flex items-center gap-x-2">
+                    <Switch v-model="tab.default" @click="updateDefaultTab" :class="[tab.default ? 'bg-artwork-buttons-create' : 'bg-gray-200', 'relative inline-flex h-4 w-8 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-artwork-buttons-create focus:ring-offset-2']">
+                    <span :class="[tab.default ? 'translate-x-4' : 'translate-x-0', 'pointer-events-none relative inline-block size-3 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out']">
+                      <span :class="[tab.default ? 'opacity-0 duration-100 ease-out' : 'opacity-100 duration-200 ease-in', 'absolute inset-0 flex size-full items-center justify-center transition-opacity']" aria-hidden="true">
+                        <svg class="size-3 text-gray-400" fill="none" viewBox="0 0 12 12">
+                          <path d="M4 8l2-2m0 0l2-2M6 6L4 4m2 2l2 2" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+                        </svg>
+                      </span>
+                      <span :class="[tab.default? 'opacity-100 duration-200 ease-in' : 'opacity-0 duration-100 ease-out', 'absolute inset-0 flex size-full items-center justify-center transition-opacity']" aria-hidden="true">
+                        <svg class="size-3 text-artwork-buttons-create" fill="currentColor" viewBox="0 0 12 12">
+                          <path d="M3.707 5.293a1 1 0 00-1.414 1.414l1.414-1.414zM5 8l-.707.707a1 1 0 001.414 0L5 8zm4.707-3.293a1 1 0 00-1.414-1.414l1.414 1.414zm-7.414 2l2 2 1.414-1.414-2-2-1.414 1.414zm3.414 2l4-4-1.414-1.414-4 4 1.414 1.414z" />
+                        </svg>
+                      </span>
+                    </span>
+                    </Switch>
+                    <div>
+                        <p class="xxsDark">{{ $t('Should this tab be set as the default tab?') }}</p>
+                    </div>
+                </div>
+                <BaseMenu has-no-offset>
+                    <MenuItem v-slot="{ active }">
+                        <a href="#" @click="editTab"
+                           :class="[active ? 'bg-artwork-navigation-color/10 text-white' : 'text-secondary', 'group flex items-center px-4 py-2 text-sm subpixel-antialiased']">
+                            <IconEdit stroke-width="1.5"
+                                      class="mr-3 h-5 w-5 text-primaryText group-hover:text-white"
+                                      aria-hidden="true"/>
+                            {{ $t('Edit') }}
+                        </a>
+                    </MenuItem>
+                    <MenuItem v-slot="{ active }">
+                        <a href="#" @click="removeTab"
+                           :class="[active ? 'bg-artwork-navigation-color/10 text-white' : 'text-secondary', 'group flex items-center px-4 py-2 text-sm subpixel-antialiased']">
+                            <IconTrash stroke-width="1.5"
+                                       class="mr-3 h-5 w-5 text-primaryText group-hover:text-white"
+                                       aria-hidden="true"/>
+                            {{ $t('Delete') }}
+                        </a>
+                    </MenuItem>
+                </BaseMenu>
+            </div>
         </div>
         <div v-if="!tabClosed">
             <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -69,7 +90,7 @@
 import draggable from "vuedraggable";
 import DropNewComponent from "@/Pages/Settings/Components/DropNewComponent.vue";
 import SvgCollection from "@/Layouts/Components/SvgCollection.vue";
-import {Menu, MenuButton, MenuItem, MenuItems} from "@headlessui/vue";
+import {Menu, MenuButton, MenuItem, MenuItems, Switch} from "@headlessui/vue";
 import IconLib from "@/Mixins/IconLib.vue";
 import AddEditTabModal from "@/Pages/Settings/Components/AddEditTabModal.vue";
 import ComponentIcons from "@/Components/Globale/ComponentIcons.vue";
@@ -79,11 +100,13 @@ import SidebarConfigElement from "@/Pages/Settings/Components/Sidebar/SidebarCon
 import SingleComponent from "@/Pages/Settings/Components/SingleComponent.vue";
 import BaseMenu from "@/Components/Menu/BaseMenu.vue";
 import ErrorComponent from "@/Layouts/Components/ErrorComponent.vue";
+import {router, usePage} from "@inertiajs/vue3";
 
 export default {
     name: "SingleTabComponent",
     mixins: [IconLib],
     components: {
+        Switch,
         ErrorComponent,
         BaseMenu,
         SingleComponent,
@@ -118,6 +141,7 @@ export default {
         }
     },
     methods: {
+        usePage,
         updateComponentOrder(components) {
             components.map((component, index) => {
                 component.order = index + 1
@@ -142,6 +166,11 @@ export default {
         },
         openTab() {
             this.tabClosed = false;
+        },
+        updateDefaultTab() {
+            router.patch(route('tab.update.default', {projectTab: this.tab.id}), {
+                default: !this.tab.default
+            });
         }
     }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -1493,6 +1493,10 @@ Route::group(['middleware' => ['auth:sanctum', 'verified']], function (): void {
                 ProjectTabController::class,
                 'addComponentWithScopes'
             ])->name('tab.add.component.with.scopes');
+
+            // patch tab.update.default
+            Route::patch('/{projectTab}/update/default', [ProjectTabController::class, 'updateDefault'])
+                ->name('tab.update.default');
         });
         Route::group(['prefix' => 'component'], function (): void {
             // index


### PR DESCRIPTION
This pull request introduces a new feature to handle default project tabs and updates various parts of the codebase to support this functionality. The most important changes include adding methods to manage default project tabs, updating the database schema, and modifying the frontend components to allow users to set a default tab.

### Backend Changes:
* [`app/Http/Controllers/ProjectController.php`](diffhunk://#diff-55e5276660f3809d6cf187d7c5568c43b8c7f701ce9f0cd5099aa08039beaf19L254-R254): Updated method calls to use the new `getDefaultOrFirstProjectTabId` method. [[1]](diffhunk://#diff-55e5276660f3809d6cf187d7c5568c43b8c7f701ce9f0cd5099aa08039beaf19L254-R254) [[2]](diffhunk://#diff-55e5276660f3809d6cf187d7c5568c43b8c7f701ce9f0cd5099aa08039beaf19L327-R327) [[3]](diffhunk://#diff-55e5276660f3809d6cf187d7c5568c43b8c7f701ce9f0cd5099aa08039beaf19L405-R405)
* [`app/Http/Controllers/ProjectTabController.php`](diffhunk://#diff-cd0624b069c92f09e22743a8c3abdf6c1389b7e417f5a75c8f38bb88d841c862R124-R129): Added a new `updateDefault` method to set a project tab as the default.
* [`artwork/Modules/ProjectTab/Models/ProjectTab.php`](diffhunk://#diff-a37df27ee1004274b926a8c7fa9375e2dda76fc23bc0210582ba9a6fb3b421c2R27-R31): Added `default` attribute to the `ProjectTab` model and cast it to a boolean.
* [`artwork/Modules/ProjectTab/Repositories/ProjectTabRepository.php`](diffhunk://#diff-94449949eea67dc25f87256741849f72dc14c77bf5288991ec33a3beef6be5bdR40-R46): Added `getDefaultOrFirstProjectTab` method to retrieve the default or first project tab.
* [`artwork/Modules/ProjectTab/Services/ProjectTabService.php`](diffhunk://#diff-96ef13d7e45e7ea0d2af0f574c39cd1ac406de667b17fbc5053e82e932afec3aR46-R55): Added methods to get the default or first project tab and its ID. [[1]](diffhunk://#diff-96ef13d7e45e7ea0d2af0f574c39cd1ac406de667b17fbc5053e82e932afec3aR46-R55) [[2]](diffhunk://#diff-96ef13d7e45e7ea0d2af0f574c39cd1ac406de667b17fbc5053e82e932afec3aL73-R83)

### Database Changes:
* [`database/migrations/2025_02_07_134749_add_default_to_project_tabs.php`](diffhunk://#diff-ddb74c5d364050cd0c7602d16d0de55984ef704c59b66cd8f4aef655183e4dd5R1-R28): Added a migration to include the `default` column in the `project_tabs` table.

### Frontend Changes:
* [`resources/js/Pages/Settings/Components/SingleTabComponent.vue`](diffhunk://#diff-1e6a94ee38715362ff19edfdb2e6f01a85362ebe926be723d53518d72e04d7acR10-R29): Added a switch to set a tab as the default and updated the component to handle this functionality. [[1]](diffhunk://#diff-1e6a94ee38715362ff19edfdb2e6f01a85362ebe926be723d53518d72e04d7acR10-R29) [[2]](diffhunk://#diff-1e6a94ee38715362ff19edfdb2e6f01a85362ebe926be723d53518d72e04d7acR51) [[3]](diffhunk://#diff-1e6a94ee38715362ff19edfdb2e6f01a85362ebe926be723d53518d72e04d7acL72-R93) [[4]](diffhunk://#diff-1e6a94ee38715362ff19edfdb2e6f01a85362ebe926be723d53518d72e04d7acR103-R109) [[5]](diffhunk://#diff-1e6a94ee38715362ff19edfdb2e6f01a85362ebe926be723d53518d72e04d7acR144) [[6]](diffhunk://#diff-1e6a94ee38715362ff19edfdb2e6f01a85362ebe926be723d53518d72e04d7acR169-R173)

### Localization Changes:
* `lang/de.json` and `lang/en.json`: Added a new localization string for the default tab setting. [[1]](diffhunk://#diff-b856eeca8165aed4012d1d98ca6e927f20366c9c1272932ad9d8004358c1f38dL2309-R2310) [[2]](diffhunk://#diff-1d56632a2d162f99c901e53b79a6224e984c14501bca3188a85dbb4b4c5e6da1L2308-R2309)

### Route Changes:
* [`routes/web.php`](diffhunk://#diff-193e04aa1705f6f3e484d7efca8f45fe4d19d0ece3b6e6880d3ea070938a1fadR1496-R1499): Added a new route for updating the default project tab.