### PR TITLE
hide_unoccupied_rooms

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -717,7 +717,8 @@ class UserController extends Controller
             'expand_days',
             'use_event_status_color',
             'show_qualifications',
-            'shift_notes'
+            'shift_notes',
+            'hide_unoccupied_rooms'
         ]));
     }
 

--- a/artwork/Modules/Room/Repositories/RoomRepository.php
+++ b/artwork/Modules/Room/Repositories/RoomRepository.php
@@ -65,7 +65,8 @@ class RoomRepository extends BaseRepository
                 $adjoiningNoAudience,
                 $startDate,
                 $endDate
-            )->orderBy('order')
+            )
+            ->orderBy('order')
             ->get();
     }
 

--- a/artwork/Modules/UserCalendarSettings/Models/UserCalendarSettings.php
+++ b/artwork/Modules/UserCalendarSettings/Models/UserCalendarSettings.php
@@ -44,7 +44,8 @@ class UserCalendarSettings extends Model
         'expand_days',
         'use_event_status_color',
         'show_qualifications',
-        'shift_notes'
+        'shift_notes',
+        'hide_unoccupied_rooms'
     ];
 
     protected $casts = [
@@ -61,7 +62,8 @@ class UserCalendarSettings extends Model
         'expand_days' => 'boolean',
         'use_event_status_color' => 'boolean',
         'show_qualifications' => 'boolean',
-        'shift_notes' => 'boolean'
+        'shift_notes' => 'boolean',
+        'hide_unoccupied_rooms' => 'boolean'
     ];
 
     public function user(): BelongsTo

--- a/database/migrations/2025_02_10_191314_add_hide_unoccupied_rooms.php
+++ b/database/migrations/2025_02_10_191314_add_hide_unoccupied_rooms.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('user_calendar_settings', function (Blueprint $table) {
+            $table->boolean('hide_unoccupied_rooms')->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('user_calendar_settings', function (Blueprint $table) {
+            $table->dropColumn('hide_unoccupied_rooms');
+        });
+    }
+};

--- a/lang/de.json
+++ b/lang/de.json
@@ -2337,5 +2337,6 @@
     "A user with this permission can schedule events directly without a request in all rooms": "Ein Nutzer mit dieser Berechtigung kann direkt Termine ohne Anfrage in allen Räumen planen",
     "Open": "Öffnen",
     "Are you sure you want to delete the event property {0}? This is not reversible.": "Möchtest du die Termin-Eigenschaft {0} wirklich löschen? Dies ist nicht rückgängig zu machen.",
-    "Delete event property": "Termin-Eigenschaft löschen"
+    "Delete event property": "Termin-Eigenschaft löschen",
+    "Hide unoccupied rooms": "Leere Räume ausblenden"
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -2336,5 +2336,6 @@
     "A user with this permission can schedule events directly without a request in all rooms": "A user with this permission can schedule events directly without a request in all rooms",
     "Open": "Open",
     "Are you sure you want to delete the event property {0}? This is not reversible.": "Are you sure you want to delete the event property {0}? This is not reversible.",
-    "Delete event property": "Delete event property"
+    "Delete event property": "Delete event property",
+    "Hide unoccupied rooms": "Hide unoccupied rooms"
 }

--- a/resources/js/Components/FunctionBars/FunctionBarCalendar.vue
+++ b/resources/js/Components/FunctionBars/FunctionBarCalendar.vue
@@ -293,6 +293,17 @@
                                             {{ $t('Use event status colour') }}
                                         </label>
                                     </div>
+                                    <div class="flex items-center py-1">
+                                        <input id="cb-use-event-status-color"
+                                               v-model="userCalendarSettings.hide_unoccupied_rooms"
+                                               type="checkbox"
+                                               class="input-checklist"/>
+                                        <label for="cb-use-event-status-color"
+                                               :class="userCalendarSettings.hide_unoccupied_rooms ? 'text-secondaryHover subpixel-antialiased' : 'text-secondary'"
+                                               class="ml-4 my-auto text-secondary cursor-pointer">
+                                            {{ $t('Hide unoccupied rooms') }}
+                                        </label>
+                                    </div>
                                 </div>
                                 <div class="flex justify-end">
                                     <button class="text-sm mx-3 mb-4" @click="saveUserCalendarSettings">
@@ -402,6 +413,7 @@ const userCalendarSettings = useForm({
     high_contrast: usePage().props.user.calendar_settings ? usePage().props.user.calendar_settings.high_contrast : false,
     expand_days: usePage().props.user.calendar_settings ? usePage().props.user.calendar_settings.expand_days : false,
     use_event_status_color: usePage().props.user.calendar_settings ? usePage().props.user.calendar_settings.use_event_status_color : false,
+    hide_unoccupied_rooms: usePage().props.user.calendar_settings ? usePage().props.user.calendar_settings.hide_unoccupied_rooms : false,
 });
 
 
@@ -608,8 +620,14 @@ const updateTimes = () => {
 }
 
 const saveUserCalendarSettings = () => {
+    let preserveState = true;
+    if(usePage().props.user.calendar_settings.hide_unoccupied_rooms !== userCalendarSettings.hide_unoccupied_rooms){
+        preserveState = false;
+    }
+
     userCalendarSettings.patch(route('user.calendar_settings.update', {user: usePage().props.user.id}), {
         preserveScroll: true,
+        preserveState: preserveState,
     })
     document.getElementById('displaySettings').click();
 }


### PR DESCRIPTION
This pull request introduces a new feature to hide unoccupied rooms in the calendar, along with necessary backend and frontend changes to support this functionality. The most important changes include updates to the `UserCalendarSettings` model, modifications to various service methods to handle the new setting, and updates to the user interface to allow users to toggle this setting.

### Backend Changes:

* **Model Update:**
  - Added a new boolean attribute `hide_unoccupied_rooms` to the `UserCalendarSettings` model. [[1]](diffhunk://#diff-944c4a20a1b41f8562369fec985150686a78bbc4217bff50aee253acd970a1cdL47-R48) [[2]](diffhunk://#diff-944c4a20a1b41f8562369fec985150686a78bbc4217bff50aee253acd970a1cdL64-R66)

* **Migration:**
  - Created a new migration to add the `hide_unoccupied_rooms` column to the `user_calendar_settings` table.

* **Service Method Modifications:**
  - Updated the `fetchFilteredRooms` method in `EventService` to accept `UserCalendarSettings` and filter rooms based on the `hide_unoccupied_rooms` setting. [[1]](diffhunk://#diff-7158881782a6445e07413e19698961fb28d16577e7434e2133abbfcf0260e691L779-R797) [[2]](diffhunk://#diff-7158881782a6445e07413e19698961fb28d16577e7434e2133abbfcf0260e691L797-R827)
  - Updated the `createEventManagementDto` method in `EventService` to pass `UserCalendarSettings` to the `fetchFilteredRooms` method. [[1]](diffhunk://#diff-7158881782a6445e07413e19698961fb28d16577e7434e2133abbfcf0260e691L1357-R1389) [[2]](diffhunk://#diff-7158881782a6445e07413e19698961fb28d16577e7434e2133abbfcf0260e691L1410-R1442)

### Frontend Changes:

* **User Interface:**
  - Added a new checkbox in `FunctionBarCalendar.vue` to toggle the `hide_unoccupied_rooms` setting. [[1]](diffhunk://#diff-ca119f6c81dd0c491e1c652431a0236e7433785c67e319f7e34a5dcfdc32d68eR296-R306) [[2]](diffhunk://#diff-ca119f6c81dd0c491e1c652431a0236e7433785c67e319f7e34a5dcfdc32d68eR416)
  - Updated the `saveUserCalendarSettings` function to handle the new setting and refresh the state if it changes.

* **Localization:**
  - Added translations for the new "Hide unoccupied rooms" setting in both English and German language files. [[1]](diffhunk://#diff-b856eeca8165aed4012d1d98ca6e927f20366c9c1272932ad9d8004358c1f38dL2340-R2341) [[2]](diffhunk://#diff-1d56632a2d162f99c901e53b79a6224e984c14501bca3188a85dbb4b4c5e6da1L2339-R2340)

These changes collectively enable users to hide unoccupied rooms in their calendar view, improving the user experience by reducing clutter.