### PR TITLE
Standard Status option

### DIFF
--- a/artwork/Modules/Event/Http/Requests/CreateEventStatusRequest.php
+++ b/artwork/Modules/Event/Http/Requests/CreateEventStatusRequest.php
@@ -24,6 +24,7 @@ class CreateEventStatusRequest extends FormRequest
         return [
             'name' => 'required|string',
             'color' => 'required|string',
+            'default' => 'required|boolean',
         ];
     }
 }

--- a/artwork/Modules/Event/Http/Requests/UpdateEventStatusRequest.php
+++ b/artwork/Modules/Event/Http/Requests/UpdateEventStatusRequest.php
@@ -25,6 +25,7 @@ class UpdateEventStatusRequest extends FormRequest
             'id' => 'required|exists:event_statuses,id',
             'name' => 'required|string',
             'color' => 'required|string',
+            'default' => 'required|boolean',
         ];
     }
 }

--- a/artwork/Modules/Event/Models/EventStatus.php
+++ b/artwork/Modules/Event/Models/EventStatus.php
@@ -5,9 +5,22 @@ namespace Artwork\Modules\Event\Models;
 use Artwork\Core\Database\Models\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 
+/**
+ * @property string $name
+ * @property string $color
+ * @property int $order
+ * @property bool $default
+ * @property int $id
+ * @property \Carbon\Carbon $created_at
+ * @property \Carbon\Carbon $updated_at
+ */
 class EventStatus extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['name', 'order', 'color'];
+    protected $fillable = ['name', 'order', 'color', 'default'];
+
+    protected $casts = [
+        'default' => 'boolean',
+    ];
 }

--- a/artwork/Modules/Event/Repositories/EventStatusRepository.php
+++ b/artwork/Modules/Event/Repositories/EventStatusRepository.php
@@ -30,4 +30,9 @@ class EventStatusRepository extends BaseRepository
 
         return $builder;
     }
+
+    public function removeDefaultStatus(): void
+    {
+        EventStatus::where('default', true)->update(['default' => false]);
+    }
 }

--- a/artwork/Modules/Event/Services/EventStatusService.php
+++ b/artwork/Modules/Event/Services/EventStatusService.php
@@ -19,18 +19,30 @@ readonly class EventStatusService
 
     public function create(array $data): EventStatus
     {
+        if($data['default']) {
+            $this->eventStatusRepository->removeDefaultStatus();
+        }
+
         // add order to the data
         $data['order'] = $this->eventStatusRepository->getNewModelQuery()->count() + 1;
 
         $status = $this->eventStatusRepository->getNewModelInstance($data);
         $this->eventStatusRepository->save($status);
+
+
+
         return $status;
     }
 
     public function update(EventStatus $eventStatus, array $data): EventStatus
     {
+        if($data['default']) {
+            $this->eventStatusRepository->removeDefaultStatus();
+        }
+
         $eventStatus->fill($data);
         $this->eventStatusRepository->save($eventStatus);
+
         return $eventStatus;
     }
 

--- a/database/migrations/2025_02_10_203811_add_default_to_event_statuses.php
+++ b/database/migrations/2025_02_10_203811_add_default_to_event_statuses.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('event_statuses', function (Blueprint $table) {
+            $table->boolean('default')->default(false);
+        });
+
+        // update first status to default
+        DB::table('event_statuses')->where('id', 1)->update(['default' => true]);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('event_statuses', function (Blueprint $table) {
+            $table->dropColumn('default');
+        });
+    }
+};

--- a/lang/de.json
+++ b/lang/de.json
@@ -2337,5 +2337,6 @@
     "A user with this permission can schedule events directly without a request in all rooms": "Ein Nutzer mit dieser Berechtigung kann direkt Termine ohne Anfrage in allen Räumen planen",
     "Open": "Öffnen",
     "Are you sure you want to delete the event property {0}? This is not reversible.": "Möchtest du die Termin-Eigenschaft {0} wirklich löschen? Dies ist nicht rückgängig zu machen.",
-    "Delete event property": "Termin-Eigenschaft löschen"
+    "Delete event property": "Termin-Eigenschaft löschen",
+    "Should this status be set as the default?": "Soll dieser Status als Standard festgelegt werden?"
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -2336,5 +2336,6 @@
     "A user with this permission can schedule events directly without a request in all rooms": "A user with this permission can schedule events directly without a request in all rooms",
     "Open": "Open",
     "Are you sure you want to delete the event property {0}? This is not reversible.": "Are you sure you want to delete the event property {0}? This is not reversible.",
-    "Delete event property": "Delete event property"
+    "Delete event property": "Delete event property",
+    "Should this status be set as the default?": "Should this status be set as the default?"
 }

--- a/resources/js/Layouts/Components/EventComponent.vue
+++ b/resources/js/Layouts/Components/EventComponent.vue
@@ -791,7 +791,7 @@ export default {
             eventStatus: null,
             eventTypeName: null,
             selectedEventType: this.eventTypes[0],
-            selectedEventStatus: this.eventStatuses[0],
+            selectedEventStatus: this.eventStatuses?.find(status => status.default),
             showProjectInfo: this.project ? true : this.calendarProjectPeriod && this.$page.props.user.calendar_settings.time_period_project_id ? true :false,
             allDayEvent: false,
             selectedProject: null,

--- a/resources/js/Pages/Projects/Components/BulkComponents/BulkBody.vue
+++ b/resources/js/Pages/Projects/Components/BulkComponents/BulkBody.vue
@@ -240,7 +240,7 @@ const {hasAdminRole} = usePermission(usePage().props),
         if (props.isInModal) {
             events.push({
                 index: events.length + 1,
-                status: props.eventStatuses ? props.eventStatuses[0] : null,
+                status: props.eventStatuses ? props.eventStatuses?.find(status => status.default) : null,
                 type: props.eventTypes ? props.eventTypes[0] : null,
                 name: props.isInModal ? '' : 'Blocker',
                 room: props.rooms ? props.rooms[0] : null,
@@ -283,7 +283,8 @@ const {hasAdminRole} = usePermission(usePage().props),
             } else {
                 router.post(route('event.store.bulk.single', {project: props.project}), {
                     event: {
-                        status: props.eventStatuses ? props.eventStatuses[0] : null,
+                        // status get the default status form the eventStatuses
+                        status: props.eventStatuses ? props.eventStatuses?.find(status => status.default) : null,
                         type: props.eventTypes ? props.eventTypes[0] : null,
                         name: props.isInModal ? '' : 'Blocker',
                         room: props.rooms ? props.rooms[0] : null,

--- a/resources/js/Pages/Settings/EventStatus/Components/AddEditEventStatusModal.vue
+++ b/resources/js/Pages/Settings/EventStatus/Components/AddEditEventStatusModal.vue
@@ -21,6 +21,26 @@
                 </div>
             </div>
 
+            <div class="flex items-center gap-x-2 mt-4">
+                <Switch v-model="eventStatus.default" :class="[eventStatus.default ? 'bg-artwork-buttons-create' : 'bg-gray-200', 'relative inline-flex h-6 w-10 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-artwork-buttons-create focus:ring-offset-2']">
+                    <span :class="[eventStatus.default ? 'translate-x-4' : 'translate-x-0', 'pointer-events-none relative inline-block size-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out']">
+                      <span :class="[eventStatus.default ? 'opacity-0 duration-100 ease-out' : 'opacity-100 duration-200 ease-in', 'absolute inset-0 flex size-full items-center justify-center transition-opacity']" aria-hidden="true">
+                        <svg class="size-4 text-gray-400" fill="none" viewBox="0 0 12 12">
+                          <path d="M4 8l2-2m0 0l2-2M6 6L4 4m2 2l2 2" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+                        </svg>
+                      </span>
+                      <span :class="[eventStatus.default? 'opacity-100 duration-200 ease-in' : 'opacity-0 duration-100 ease-out', 'absolute inset-0 flex size-full items-center justify-center transition-opacity']" aria-hidden="true">
+                        <svg class="size-4 text-artwork-buttons-create" fill="currentColor" viewBox="0 0 12 12">
+                          <path d="M3.707 5.293a1 1 0 00-1.414 1.414l1.414-1.414zM5 8l-.707.707a1 1 0 001.414 0L5 8zm4.707-3.293a1 1 0 00-1.414-1.414l1.414 1.414zm-7.414 2l2 2 1.414-1.414-2-2-1.414 1.414zm3.414 2l4-4-1.414-1.414-4 4 1.414 1.414z" />
+                        </svg>
+                      </span>
+                    </span>
+                </Switch>
+                <div>
+                    <p class="xsDark">{{ $t('Should this status be set as the default?') }}</p>
+                </div>
+            </div>
+
             <div class="flex items-center justify-center mt-5">
                 <FormButton type="submit" :text="eventStatusToEdit ? $t('Save') : $t('Create')" />
             </div>
@@ -36,6 +56,7 @@ import ColorPickerComponent from "@/Components/Globale/ColorPickerComponent.vue"
 import {useForm} from "@inertiajs/vue3";
 import TextInputComponent from "@/Components/Inputs/TextInputComponent.vue";
 import FormButton from "@/Layouts/Components/General/Buttons/FormButton.vue";
+import {Switch} from "@headlessui/vue";
 
 const props = defineProps({
     eventStatusToEdit: {
@@ -48,7 +69,8 @@ const props = defineProps({
 const eventStatus = useForm({
     id: props.eventStatusToEdit ? props.eventStatusToEdit.id : null,
     name: props.eventStatusToEdit ? props.eventStatusToEdit.name : '',
-    color: props.eventStatusToEdit ? props.eventStatusToEdit.color : '#ccc'
+    color: props.eventStatusToEdit ? props.eventStatusToEdit.color : '#ccc',
+    default: props.eventStatusToEdit ? props.eventStatusToEdit.default : false
 })
 const emits = defineEmits(['closeModal'])
 const setColor = (color) => {

--- a/resources/js/Pages/Settings/EventStatus/Index.vue
+++ b/resources/js/Pages/Settings/EventStatus/Index.vue
@@ -47,7 +47,7 @@
                                         <p class="text-sm font-semibold leading-6 text-gray-900 flex items-center gap-x-2">
                                             <span class="h-14 w-14 block rounded-full border" :style="{'backgroundColor' : element.color }"/>
                                             {{ element.name }}
-                                            <span v-if="element.id === 1" class="inline-flex items-center rounded-md bg-gray-50 px-2 py-1 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/10 ml-10">{{ $t('Default') }}</span>
+                                            <span v-if="element.default" class="inline-flex items-center rounded-md bg-gray-50 px-2 py-1 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/10 ml-10">{{ $t('Default') }}</span>
                                         </p>
                                     </div>
                                 </div>
@@ -63,7 +63,7 @@
                                                 {{$t('Edit')}}
                                             </a>
                                         </MenuItem>
-                                        <MenuItem v-if="element.id !== 1" @click="openDeleteEventStatusModal(element)"
+                                        <MenuItem v-if="!element.default" @click="openDeleteEventStatusModal(element)"
                                                   v-slot="{ active }">
                                             <a :class="[active ? 'bg-artwork-navigation-color/10 text-white' : 'text-secondary', 'group flex items-center px-4 py-2 text-sm subpixel-antialiased cursor-pointer']">
                                                 <IconTrash stroke-width="1.5"


### PR DESCRIPTION
This pull request introduces a new "default" property to the `EventStatus` model, ensuring that only one status can be set as the default at any given time. The changes include updates to the model, validation rules, repository, service, and front-end components to support this new functionality.

### Backend Changes:
* [`artwork/Modules/Event/Models/EventStatus.php`](diffhunk://#diff-55a361e121b05e418afba0ff0bdb7aa03823b9aca4fe4c8e8a05e6859ed03871R8-R25): Added `default` property with appropriate casting and updated the `$fillable` array.
* `artwork/Modules/Event/Http/Requests/CreateEventStatusRequest.php` and `artwork/Modules/Event/Http/Requests/UpdateEventStatusRequest.php`: Updated validation rules to include the `default` property. [[1]](diffhunk://#diff-88fe12126ab8655ecd0a446057cf2571373d9386b6a5c9b6f9e157bbf8153b66R27) [[2]](diffhunk://#diff-86826264aa97830fb12a7ed0ecc2de7944c1a637aeb6c03ce45f4470dc6bf252R28)
* [`artwork/Modules/Event/Repositories/EventStatusRepository.php`](diffhunk://#diff-ca2611d04c8387d6f29a6594fcec0c15873206e545ed22d42b66183b8d0bf311R33-R37): Added `removeDefaultStatus` method to unset the current default status.
* [`artwork/Modules/Event/Services/EventStatusService.php`](diffhunk://#diff-ebd9a44bfba68af57031cbbde458281602f7912a8f6eb50939990e6fc2c00c34R22-R45): Modified `create` and `update` methods to call `removeDefaultStatus` when a new default status is set.
* [`database/migrations/2025_02_10_203811_add_default_to_event_statuses.php`](diffhunk://#diff-b848568b2401cb06e10ed5674ddd6337e164c495680522c35f0530d0938e8dbdR1-R32): Added migration to include the `default` column in the `event_statuses` table and set the first status as default.

### Frontend Changes:
* `resources/js/Layouts/Components/EventComponent.vue` and `resources/js/Pages/Projects/Components/BulkComponents/BulkBody.vue`: Updated to select the default status when initializing components. [[1]](diffhunk://#diff-3d47a880989dddc7caf02d74e6c640491f1ec24975c6591bcefefaa71b470513L794-R794) [[2]](diffhunk://#diff-ca0349412b53d917e1981731768b872c84d842c3658dcd8c1af785d77debb302L243-R243) [[3]](diffhunk://#diff-ca0349412b53d917e1981731768b872c84d842c3658dcd8c1af785d77debb302L286-R287)
* [`resources/js/Pages/Settings/EventStatus/Components/AddEditEventStatusModal.vue`](diffhunk://#diff-4bb7a613fd2a0f29257aa01e51428266547165da4899aa21391272312dee5f9aR24-R43): Added a switch component to set the default status and updated the form to include the `default` property. [[1]](diffhunk://#diff-4bb7a613fd2a0f29257aa01e51428266547165da4899aa21391272312dee5f9aR24-R43) [[2]](diffhunk://#diff-4bb7a613fd2a0f29257aa01e51428266547165da4899aa21391272312dee5f9aR59) [[3]](diffhunk://#diff-4bb7a613fd2a0f29257aa01e51428266547165da4899aa21391272312dee5f9aL51-R73)
* [`resources/js/Pages/Settings/EventStatus/Index.vue`](diffhunk://#diff-ec5ee5802a634c2d468b2bede274f2d24230ac2385fc4e14279bf2f518426041L50-R50): Updated to display the default status label and prevent deletion of the default status. [[1]](diffhunk://#diff-ec5ee5802a634c2d468b2bede274f2d24230ac2385fc4e14279bf2f518426041L50-R50) [[2]](diffhunk://#diff-ec5ee5802a634c2d468b2bede274f2d24230ac2385fc4e14279bf2f518426041L66-R66)

### Localization:
* `lang/de.json` and `lang/en.json`: Added translations for the new default status prompt. [[1]](diffhunk://#diff-b856eeca8165aed4012d1d98ca6e927f20366c9c1272932ad9d8004358c1f38dL2340-R2341) [[2]](diffhunk://#diff-1d56632a2d162f99c901e53b79a6224e984c14501bca3188a85dbb4b4c5e6da1L2339-R2340)