### PR TITLE
disable update page if has no notion api token

### DIFF
--- a/artwork/Core/Http/Middleware/HandleInertiaRequests.php
+++ b/artwork/Core/Http/Middleware/HandleInertiaRequests.php
@@ -77,6 +77,7 @@ class HandleInertiaRequests extends Middleware
                 'calendar_settings' => $calendarSettings,
                 'module_settings' => $this->moduleSettingsService->getModuleSettings(),
                 'high_contrast_percent' => $calendarSettings?->getAttribute('high_contrast') ? 75 : 15,
+                'isNotionKeySet' => config('app.notion_api_token') !== null && config('app.notion_api_token') !== '',
             ]
         );
     }

--- a/config/app.php
+++ b/config/app.php
@@ -17,6 +17,8 @@ return [
     */
 
     'name' => env('APP_NAME', 'Laravel'),
+
+    'notion_api_token' => env('NOTION_API_TOKEN', ''),
     /*
     |--------------------------------------------------------------------------
     | Application Environment

--- a/resources/js/Layouts/AppLayout.vue
+++ b/resources/js/Layouts/AppLayout.vue
@@ -490,7 +490,7 @@ export default {
                         route().current('budget-settings.templates')
                 },
                 {
-                    has_permission: true,
+                    has_permission: usePage().props.isNotionKeySet,
                     name: 'Updates',
                     href: route('notion.index'),
                     isCurrent: route().current('notion.index')


### PR DESCRIPTION
This pull request introduces changes to integrate Notion API token configuration and conditional rendering based on the presence of this token. The most important changes include adding a new configuration entry for the Notion API token, updating middleware to check for this token, and modifying the frontend to conditionally render based on the token's presence.

### Notion API Integration:

* [`config/app.php`](diffhunk://#diff-950397cc5ef29707b54d0c774bd94af85836bab1a27f2f86533d832d25caf224R20-R21): Added a new configuration entry `notion_api_token` to store the Notion API token.
* [`artwork/Core/Http/Middleware/HandleInertiaRequests.php`](diffhunk://#diff-3c641c0678fffc9ff7157043d39fdbdd27a37453e799bb8354df65d7e9998793R80): Updated the `share` method to include a new key `isNotionKeySet` that checks if the Notion API token is set.

### Frontend Conditional Rendering:

* [`resources/js/Layouts/AppLayout.vue`](diffhunk://#diff-838512c9724e89f661acdd92e815d215e96d846fcd2aec3b785820a75448648aL493-R493): Modified the `has_permission` property to use the new `isNotionKeySet` prop, which determines if the Notion API token is set.