### PR TITLE
Artwork 45 remove events where are deleted from export

### DIFF
--- a/artwork/Modules/Event/Repositories/EventRepository.php
+++ b/artwork/Modules/Event/Repositories/EventRepository.php
@@ -328,6 +328,7 @@ class EventRepository extends BaseRepository
 //                    }
 //                }
 //            )
+                ->where('deleted_at', null)
             ->orderBy('start_time');
 
         return $query->get();

--- a/artwork/Modules/Event/Services/EventCollectionService.php
+++ b/artwork/Modules/Event/Services/EventCollectionService.php
@@ -269,6 +269,8 @@ class EventCollectionService
             $roomEventsQuery->where('is_loud', false);
         }
 
+        $roomEventsQuery->where('deleted_at', null);
+
         // order $roomEventsQuery by start_time
         $roomEventsQuery->orderBy('start_time');
 


### PR DESCRIPTION
This pull request includes changes to ensure that only non-deleted events are considered in queries within the `EventRepository` and `EventCollectionService` classes.

Changes to filter out deleted events:

* [`artwork/Modules/Event/Repositories/EventRepository.php`](diffhunk://#diff-ad8563fccdbbb9ed903595e573b08f40dd34875ae3e1a43871a2ac24a40e8480R331): Added a condition to exclude events with a non-null `deleted_at` field in the query.
* [`artwork/Modules/Event/Services/EventCollectionService.php`](diffhunk://#diff-b316dac4016486ef0a5a50fee4cb8cc652d0bc6c6e07498a2fb2f34485d866e8R272-R273): Added a condition to exclude events with a non-null `deleted_at` field in the `roomEventsQuery`.