### PR TITLE
fix filter apply if event properties empty

### DIFF
--- a/resources/js/Layouts/Components/IndividualCalendarFilterComponent.vue
+++ b/resources/js/Layouts/Components/IndividualCalendarFilterComponent.vue
@@ -438,7 +438,7 @@ export default {
             this.filterArray.roomFilters.allDayFree = filter.allDayFree;
             this.filterArray.eventProperties.forEach(
                 (eventProperty) => {
-                    eventProperty.checked = filter.eventProperties.includes(eventProperty.id);
+                    eventProperty.checked = filter.eventProperties?.includes(eventProperty.id);
                 }
             );
             this.reloadChanges();


### PR DESCRIPTION
This pull request introduces a small but important change to the `IndividualCalendarFilterComponent.vue` file. The change ensures that the code handles cases where `filter.eventProperties` might be `null` or `undefined`.

* [`resources/js/Layouts/Components/IndividualCalendarFilterComponent.vue`](diffhunk://#diff-2a7d1abb672700da33861418f864a38fb183757ee0d61394336525740f7497b1L441-R441): Added optional chaining to safely check if `filter.eventProperties` includes `eventProperty.id`.