### PR TITLE
add own window for copy events

### DIFF
--- a/resources/js/Components/Menu/BaseMenu.vue
+++ b/resources/js/Components/Menu/BaseMenu.vue
@@ -27,6 +27,7 @@
                            :tooltip-text="$t(translationKey)"
                            :icon="icon"
                            :icon-size="dotsSize"
+                           :stroke="strokeWidth"
                            :class="[dotsColor, dotsSize, whiteIcon ? 'text-white' : '']"
                        />
                    </div>
@@ -39,7 +40,7 @@
                         leave-active-class="transition ease-in duration-75"
                         leave-from-class="transform opacity-100 scale-100"
                         leave-to-class="transform opacity-0 scale-95">
-                <MenuItems class="z-50 rounded-lg bg-artwork-navigation-background shadow-xl ring-1 ring-black ring-opacity-5 focus:outline-none" :class="[menuWidth]">
+                <MenuItems class="z-50 rounded-lg  shadow-xl ring-1 ring-black ring-opacity-5 focus:outline-none" :class="[menuWidth, whiteMenuBackground ? 'bg-white' : 'bg-artwork-navigation-background']">
                     <div>
                         <slot />
                     </div>
@@ -122,6 +123,16 @@ export default defineComponent({
             type: Boolean,
             required: false,
             default: true,
+        },
+        whiteMenuBackground: {
+            type: Boolean,
+            required: false,
+            default: false,
+        },
+        strokeWidth: {
+            type: [String, Number],
+            required: false,
+            default: 1.5,
         },
     },
 

--- a/resources/js/Pages/Projects/Components/BulkComponents/BulkSingleEvent.vue
+++ b/resources/js/Pages/Projects/Components/BulkComponents/BulkSingleEvent.vue
@@ -159,9 +159,48 @@
                <div class="flex items-center gap-x-3">
                    <ToolTipComponent icon="IconNote" v-if="!isInModal" :tooltip-text="$t('Edit the description')" stroke="1.5" @click="openNoteModal = true" />
                    <ToolTipDefault :tooltip-text="$t('Set the event to all-day')" left show24-h-icon icon-classes="w-6 h-6" v-if="event.start_time && event.end_time && !event.copy && !isInModal" @click="removeTime"/>
-                   <IconCopy @click="event.copy = true" v-if="!event.copy"
-                             class="w-6 h-6 text-artwork-buttons-context cursor-pointer hover:text-artwork-buttons-hover transition-all duration-150 ease-in-out"
-                             stroke-width="2"/>
+                   <BaseMenu show-custom-icon dots-color="!text-artwork-buttons-context" stroke-width="2" icon="IconCopy" translation-key="Copy" menu-width="w-fit" white-menu-background>
+                       <div class="flex items-center gap-x-2 p-3">
+                           <IconPlus class="w-6 h-6 text-artwork-buttons-context" stroke-width="2"/>
+                           <input
+                               type="number"
+                               class="input h-12 w-14"
+                               placeholder="Anzahl"
+                               v-model="event.copyCount"
+                               min="1"
+                               minlength="1"
+                               max="1000"
+                           />
+                           <Listbox as="div" class="relative" v-model="event.copyType" id="room">
+                               <ListboxButton class="menu-button">
+                                   <div class="flex-grow flex text-left xsDark !w-12 truncate">
+                                       {{ event.copyType?.name }}
+                                   </div>
+                                   <IconChevronDown stroke-width="1.5" class="h-5 w-5 text-primary" aria-hidden="true"/>
+                               </ListboxButton>
+                               <ListboxOptions
+                                   class="w-full rounded-lg bg-primary max-h-32 overflow-y-auto text-sm absolute z-30">
+                                   <ListboxOption v-for="copyType in copyTypes"
+                                                  class="hover:bg-indigo-800 text-secondary cursor-pointer p-2 flex justify-between"
+                                                  :key="copyType.name"
+                                                  :value="copyType"
+                                                  v-slot="{ active, selected }">
+                                       <div :class="[selected ? 'xsWhiteBold' : 'xsLight', 'flex']">
+                                           {{ copyType.name }}
+                                       </div>
+                                       <IconCheck stroke-width="1.5" v-if="selected" class="h-5 w-5 text-success"
+                                                  aria-hidden="true"/>
+                                   </ListboxOption>
+                               </ListboxOptions>
+                           </Listbox>
+                           <IconCircleCheckFilled @click="createCopyByEventWithData(event)"
+                                                  class="w-8 h-8 text-artwork-buttons-create cursor-pointer hover:text-artwork-buttons-hover transition-all duration-150 ease-in-out"
+                                                  stroke-width="2"/>
+                           <IconX @click="event.copy = false"
+                                  class="w-6 h-6 text-artwork-buttons-context cursor-pointer hover:text-artwork-buttons-hover transition-all duration-150 ease-in-out"
+                                  stroke-width="2"/>
+                       </div>
+                   </BaseMenu>
                    <Menu v-if="!isInModal"
                          as="div"
                          class="text-sm cursor-pointer flex flex-row items-center bg-transparent">
@@ -199,46 +238,7 @@
                            </transition>
                        </div>
                    </Menu>
-                   <div v-if="event.copy" class="flex items-center gap-x-2">
-                       <IconPlus class="w-6 h-6 text-artwork-buttons-context" stroke-width="2"/>
-                       <input
-                           type="number"
-                           class="input h-12 w-14"
-                           placeholder="Anzahl"
-                           v-model="event.copyCount"
-                           min="1"
-                           minlength="1"
-                           max="1000"
-                       />
-                       <Listbox as="div" class="relative" v-model="event.copyType" id="room">
-                           <ListboxButton class="menu-button">
-                               <div class="flex-grow flex text-left xsDark !w-12 truncate">
-                                   {{ event.copyType?.name }}
-                               </div>
-                               <IconChevronDown stroke-width="1.5" class="h-5 w-5 text-primary" aria-hidden="true"/>
-                           </ListboxButton>
-                           <ListboxOptions
-                               class="w-full rounded-lg bg-primary max-h-32 overflow-y-auto text-sm absolute z-30">
-                               <ListboxOption v-for="copyType in copyTypes"
-                                              class="hover:bg-indigo-800 text-secondary cursor-pointer p-2 flex justify-between"
-                                              :key="copyType.name"
-                                              :value="copyType"
-                                              v-slot="{ active, selected }">
-                                   <div :class="[selected ? 'xsWhiteBold' : 'xsLight', 'flex']">
-                                       {{ copyType.name }}
-                                   </div>
-                                   <IconCheck stroke-width="1.5" v-if="selected" class="h-5 w-5 text-success"
-                                              aria-hidden="true"/>
-                               </ListboxOption>
-                           </ListboxOptions>
-                       </Listbox>
-                       <IconCircleCheckFilled @click="createCopyByEventWithData(event)"
-                                              class="w-8 h-8 text-artwork-buttons-create cursor-pointer hover:text-artwork-buttons-hover transition-all duration-150 ease-in-out"
-                                              stroke-width="2"/>
-                       <IconX @click="event.copy = false"
-                              class="w-6 h-6 text-artwork-buttons-context cursor-pointer hover:text-artwork-buttons-hover transition-all duration-150 ease-in-out"
-                              stroke-width="2"/>
-                   </div>
+
                </div>
            </div>
        </div>
@@ -286,6 +286,7 @@ import {computed, onMounted, ref} from "vue";
 import ToolTipComponent from "@/Components/ToolTips/ToolTipComponent.vue";
 import AddEditEventNoteModal from "@/Pages/Projects/Components/BulkComponents/AddEditEventNoteModal.vue";
 import {inject} from "vue";
+import BaseMenu from "@/Components/Menu/BaseMenu.vue";
 
 const props = defineProps({
     event: {


### PR DESCRIPTION
This pull request includes several updates to the `BaseMenu` component and its integration in other parts of the application. The changes mainly focus on adding new props to `BaseMenu` and updating its usage in the `BulkSingleEvent` component.

### Updates to `BaseMenu` component:

* Added new props `whiteMenuBackground` and `strokeWidth` to the `BaseMenu` component to allow more customization. (`resources/js/Components/Menu/BaseMenu.vue`, [[1]](diffhunk://#diff-d3a44d7347d46fcaa048a05c6531186653dca3b3a2f77d8769bab110514511b4R30) [[2]](diffhunk://#diff-d3a44d7347d46fcaa048a05c6531186653dca3b3a2f77d8769bab110514511b4L42-R43) [[3]](diffhunk://#diff-d3a44d7347d46fcaa048a05c6531186653dca3b3a2f77d8769bab110514511b4R127-R136)

### Integration of `BaseMenu` in `BulkSingleEvent` component:

* Replaced the existing menu implementation with the `BaseMenu` component, providing a more consistent and customizable menu experience. (`resources/js/Pages/Projects/Components/BulkComponents/BulkSingleEvent.vue`, [[1]](diffhunk://#diff-5d900e48409d43e8255ba95790d15ac6c992c72951f8bb9fdaa20fdcdfdb70c5L162-R163) [[2]](diffhunk://#diff-5d900e48409d43e8255ba95790d15ac6c992c72951f8bb9fdaa20fdcdfdb70c5R203-R241)
* Imported `BaseMenu` in the `BulkSingleEvent` component to enable its usage. (`resources/js/Pages/Projects/Components/BulkComponents/BulkSingleEvent.vue`, [resources/js/Pages/Projects/Components/BulkComponents/BulkSingleEvent.vueR289](diffhunk://#diff-5d900e48409d43e8255ba95790d15ac6c992c72951f8bb9fdaa20fdcdfdb70c5R289))