### PR TITLE
add line under time block if sorted by day

### DIFF
--- a/resources/js/Pages/Projects/Components/BulkComponents/BulkBody.vue
+++ b/resources/js/Pages/Projects/Components/BulkComponents/BulkBody.vue
@@ -46,23 +46,23 @@
 
         <BulkHeader v-model="timeArray" :is-in-modal="isInModal"/>
         <div :class="isInModal ? 'min-h-96 max-h-96 overflow-y-scroll' : ''">
-            <div v-if="events.length > 0"
-                 v-for="(event, index) in events"
-                 class="mb-4">
-                <BulkSingleEvent
-                    :can-edit-component="canEditComponent"
-                    :rooms="rooms"
-                    :event_types="eventTypes"
-                    :time-array="timeArray"
-                    :event="event"
-                    :copy-types="copyTypes"
-                    :index="index"
-                    :is-in-modal="isInModal"
-                    @open-event-component="onOpenEventComponent"
-                    @delete-current-event="deleteCurrentEvent"
-                    @create-copy-by-event-with-data="createCopyByEventWithData"
-                    :event-statuses="eventStatuses"
-                />
+            <div v-if="events.length > 0" v-for="(event, index) in events" class="mb-4">
+                <div :id="index" :class="(events[index]?.day !== events[index + 1]?.day) && usePage().props.user.bulk_sort_id === 3 ? 'border-b-2 border-dashed pb-3' : ''">
+                    <BulkSingleEvent
+                        :can-edit-component="canEditComponent"
+                        :rooms="rooms"
+                        :event_types="eventTypes"
+                        :time-array="timeArray"
+                        :event="event"
+                        :copy-types="copyTypes"
+                        :index="index"
+                        :is-in-modal="isInModal"
+                        @open-event-component="onOpenEventComponent"
+                        @delete-current-event="deleteCurrentEvent"
+                        @create-copy-by-event-with-data="createCopyByEventWithData"
+                        :event-statuses="eventStatuses"
+                    />
+                </div>
             </div>
             <div v-else class="flex items-center h-24 print:hidden">
                 <AlertComponent :text="$t('No events found. Click on the plus (+) icon to create an event')" type="info"
@@ -173,7 +173,7 @@ const {hasAdminRole} = usePermission(usePage().props),
         },
         event_properties: {
             type: Array,
-            required: true
+            required: false
         }
     }),
     roomCollisions = ref([]),


### PR DESCRIPTION
This pull request includes changes to the `BulkBody.vue` component to improve the handling and display of events.

Improvements to event display and handling:

* Added conditional styling to separate events by day when `bulk_sort_id` is 3, using a dashed border. (`resources/js/Pages/Projects/Components/BulkComponents/BulkBody.vue`)
* Fixed formatting by closing the `v-for` loop div properly. (`resources/js/Pages/Projects/Components/BulkComponents/BulkBody.vue`)

Changes to event properties:

* Made the `event_properties` prop optional instead of required. (`resources/js/Pages/Projects/Components/BulkComponents/BulkBody.vue`)