### PR TITLE
fix weekly working hours

### DIFF
--- a/artwork/Modules/User/Services/WorkingHourService.php
+++ b/artwork/Modules/User/Services/WorkingHourService.php
@@ -207,7 +207,7 @@ class WorkingHourService
             $differenceInMinutes = $actualShiftTimeInMinutes - $totalPlannedWorkingHoursInMinutes;
 
             // Konvertiere die Minuten in Stunden und Minuten für die Ausgabe
-            $weeklyWorkingHours[$weekStart->format('W')] = [
+            $weeklyWorkingHours[ltrim($weekStart->format('W'), '0')] = [
                 'planned_hours' => $this->convertMinutesInHours($totalPlannedWorkingHoursInMinutes),
                 'actual_hours' => $this->convertMinutesInHours($actualShiftTimeInMinutes),
                 'difference' => $this->convertMinutesInHours($differenceInMinutes)

--- a/resources/js/Pages/Shifts/ShiftPlan.vue
+++ b/resources/js/Pages/Shifts/ShiftPlan.vue
@@ -71,7 +71,6 @@
                 </ShiftPlanFunctionBar>
             </div>
 
-
             <div class="z-40" :style="{ '--dynamic-height': windowHeight + 'px' }">
                 <div ref="shiftPlan" id="shiftPlan" class="bg-white flex-grow"
                      :class="[isFullscreen ? 'overflow-y-auto' : '', showUserOverview ? ' max-h-[var(--dynamic-height)] overflow-y-scroll' : '',' max-h-[var(--dynamic-height)] overflow-y-scroll overflow-x-scroll']">


### PR DESCRIPTION
This pull request includes changes to improve the readability and functionality of the code in two different files. The most important changes include modifying the key format in the `calculateWeeklyWorkingHours` function and improving the layout structure in the `ShiftPlan.vue` component.

Improvements to `calculateWeeklyWorkingHours` function:

* [`artwork/Modules/User/Services/WorkingHourService.php`](diffhunk://#diff-05d9330f37a7ba86d74e9aecac9ecc5471ef9d5a565182ebbc34d9cb55d74cebL210-R210): Modified the key format for weekly working hours to remove leading zeros from the week number.

Layout improvements in `ShiftPlan.vue` component:

* [`resources/js/Pages/Shifts/ShiftPlan.vue`](diffhunk://#diff-69558a693ec3368b76c8655d2d91ba1e5208b8864d8e0bc0b9802796653a8aafL74): Removed an unnecessary blank line to improve code readability.