### PR TITLE
fix broadcast for decline event

### DIFF
--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -1924,7 +1924,7 @@ class EventController extends Controller
         $this->notificationService->setNotificationTo($event->creator);
         $this->notificationService->createNotification();
 
-        //broadcast(new EventCreated($event, $event->room_id));
+        broadcast(new EventCreated($event, $roomId));
     }
 
     public function getCollisionCount(Request $request): int


### PR DESCRIPTION
This pull request includes a change to the `declineEvent` method in the `EventController` class to fix a broadcasting issue.

* [`app/Http/Controllers/EventController.php`](diffhunk://#diff-e9e47c7018c1905fd246eae03c806f9201694932ce9a583c41431dc8896bcbdcL1927-R1927): Modified the `broadcast` call in the `declineEvent` method to use `$roomId` instead of `$event->room_id`.