### PR TITLE
fix notification typ. add translation

### DIFF
--- a/artwork/Modules/Notification/Enums/NotificationEnum.php
+++ b/artwork/Modules/Notification/Enums/NotificationEnum.php
@@ -146,7 +146,7 @@ enum NotificationEnum: string
     public function title(): string
     {
         return match ($this) {
-            self::NOTIFICATION_ROOM_ANSWER,
+            self::NOTIFICATION_ROOM_ANSWER => "Room requests answered",
             self::NOTIFICATION_ROOM_REQUEST => "Room requests confirmed or declined",
             self::NOTIFICATION_CONFLICT => "Event conflicts",
             self::NOTIFICATION_EVENT_CHANGED => "Event changes",
@@ -185,7 +185,7 @@ enum NotificationEnum: string
     public function description(): string
     {
         return match ($this) {
-            self::NOTIFICATION_ROOM_ANSWER,
+            self::NOTIFICATION_ROOM_ANSWER => "Find out if your room requests has been answered.",
             self::NOTIFICATION_ROOM_REQUEST => "Find out if your room requests have been confirmed or declined.",
             self::NOTIFICATION_CONFLICT => "Be notified as soon as someone schedules an appointment that conflicts with one of your appointments.",
             self::NOTIFICATION_EVENT_CHANGED => "Find out if there have been any changes to your appointments or if an appointment has been cancelled.",

--- a/lang/de.json
+++ b/lang/de.json
@@ -2379,5 +2379,9 @@
     "areas": "Bereiche",
     "Active filters": "Aktive Filter",
     "Your active filters. Click on a filter to remove it.": "Deine aktiven Filter. Klicke auf einen Filter, um ihn zu entfernen.",
-    "General Filters": "Allgemeine Filter"
+    "General Filters": "Allgemeine Filter",
+    "Room requests answered": "Raumanfragen beantwortet",
+    "Find out if your room requests has been answered.": "Finde heraus, ob deine Raumanfragen beantwortet wurden.",
+    "Room request reminder": "Raumanfrage-Erinnerung",
+    "Find out if there are any room requests that need to be confirmed or declined.": "Finde heraus, ob es Raumanfragen gibt, die bestätigt oder abgelehnt werden müssen."
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -2378,5 +2378,9 @@
     "areas": "Areas",
     "Active filters": "Active filters",
     "Your active filters. Click on a filter to remove it.": "Your active filters. Click on a filter to remove it.",
-    "General Filters": "General Filters"
+    "General Filters": "General Filters",
+    "Room requests answered": "Room requests answered",
+    "Find out if your room requests has been answered.": "Find out if your room requests has been answered.",
+    "Room request reminder": "Room request reminder",
+    "Find out if there are any room requests that need to be confirmed or declined.": "Find out if there are any room requests that need to be confirmed or declined."
 }


### PR DESCRIPTION
This pull request includes updates to the notification messages and translations for room requests in the `artwork/Modules/Notification/Enums/NotificationEnum.php` file and the translation files. The most important changes include adding specific descriptions for room request notifications and updating the translation files to include these new messages.

Updates to notification messages:

* [`artwork/Modules/Notification/Enums/NotificationEnum.php`](diffhunk://#diff-3eebf40dc990a3d8156adc5a61aeac56427af4d7a44bba52c0d8859580c7e787L149-R149): Added specific descriptions for `self::NOTIFICATION_ROOM_ANSWER` in both the `title()` and `description()` methods. [[1]](diffhunk://#diff-3eebf40dc990a3d8156adc5a61aeac56427af4d7a44bba52c0d8859580c7e787L149-R149) [[2]](diffhunk://#diff-3eebf40dc990a3d8156adc5a61aeac56427af4d7a44bba52c0d8859580c7e787L188-R188)

Updates to translation files:

* [`lang/de.json`](diffhunk://#diff-b856eeca8165aed4012d1d98ca6e927f20366c9c1272932ad9d8004358c1f38dL2382-R2386): Added translations for "Room requests answered" and "Find out if your room requests has been answered."
* [`lang/en.json`](diffhunk://#diff-1d56632a2d162f99c901e53b79a6224e984c14501bca3188a85dbb4b4c5e6da1L2381-R2385): Added translations for "Room requests answered" and "Find out if your room requests has been answered."