### PR TITLE
fix month jump

### DIFF
--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -197,6 +197,20 @@ class EventController extends Controller
             false
         );
 
+        $months = [];
+        foreach ($period as $periodObject) {
+            $date = Carbon::parse($periodObject->withoutFormat);
+            $month = $date->format('m.Y');
+            if (!array_key_exists($month, $months)) {
+                $months[$month] = [
+                    'first_day_in_period' => $date->format('Y-m-d'),
+                    'month' => $date->monthName,
+                    'year' => $date->format('y'),
+                ];
+            }
+        }
+
+
         $rooms = $this->calendarDataService->getFilteredRooms(
             $userCalendarFilter,
             $userCalendarSettings,
@@ -253,6 +267,7 @@ class EventController extends Controller
             'first_project_shift_tab_id' => $this->projectTabService
                 ->getFirstProjectTabWithTypeIdOrFirstProjectTabId(ProjectTabComponentEnum::SHIFT_TAB),
             'projectNameUsedForProjectTimePeriod' => $project?->name ?? null,
+            'months' => $months,
         ]);
     }
 

--- a/resources/js/Pages/Calendar/Index.vue
+++ b/resources/js/Pages/Calendar/Index.vue
@@ -31,6 +31,10 @@ const props = defineProps({
         type: Object,
         required: true
     },
+    months: {
+        type: Object,
+        required: true
+    },
     calendar: {
         type: Object,
         required: true


### PR DESCRIPTION
This pull request includes updates to the `viewEventIndex` method in `EventController.php` and changes to the `props` definition in `Index.vue` to handle a new `months` property. The most important changes are as follows:

### Changes in `EventController.php`:

* Added logic to generate a `months` array from the given `period`, which includes the first day in the period, month name, and year.
* Updated the view data to include the newly created `months` array.

### Changes in `Index.vue`:

* Added a new `months` property to the `props` definition, ensuring it is of type `Object` and required.