### PR TITLE
remove translation on tab in project, change notification setting texts

### DIFF
--- a/artwork/Core/Console/Commands/UpdateArtwork.php
+++ b/artwork/Core/Console/Commands/UpdateArtwork.php
@@ -2,6 +2,7 @@
 
 namespace Artwork\Core\Console\Commands;
 
+use Artwork\Modules\Notification\Models\NotificationSetting;
 use Artwork\Modules\ProjectManagementBuilder\Services\ProjectManagementBuilderService;
 use Database\Seeders\ProjectManagementBuilderSeed;
 use Illuminate\Console\Command;
@@ -52,6 +53,15 @@ class UpdateArtwork extends Command
 
         $this->info('Update Shift-Qualification-Icons');
         $this->call('db:seed', ['--class' => 'ShiftQualificationIconsSeeder']);
+        $this->info('----------------------------------------------------------');
+
+        $this->info('Change Notification Settings');
+
+        NotificationSetting::where('type', 'NOTIFICATION_ROOM_ANSWER')->update([
+            'title' => 'Room requests answered',
+            'description' => 'Find out if your room requests has been answered.',
+        ]);
+
         $this->info('----------------------------------------------------------');
     }
 }

--- a/resources/js/Pages/Projects/Tab/Components/ProjectHeaderComponent.vue
+++ b/resources/js/Pages/Projects/Tab/Components/ProjectHeaderComponent.vue
@@ -309,7 +309,7 @@ export default {
                                   :href="route('projects.tab', {project: headerObject.project.id, projectTab: tab.id})"
                                   :class="[tab.id === headerObject.currentTabId ? 'border-artwork-buttons-hover text-artwork-buttons-hover' : 'border-transparent hover:text-gray-600 hover:border-gray-300 text-artwork-context-dark', 'whitespace-nowrap py-2 px-1 border-b-2 font-black duration-300 ease-in-out']"
                                   :aria-current="tab.id === headerObject.currentTabId ? 'page' : undefined">
-                                {{ $t(tab.name) }}
+                                {{ tab.name }}
                             </Link>
                         </nav>
                     </div>


### PR DESCRIPTION
This pull request includes updates to the `UpdateArtwork` command and a minor change to the `ProjectHeaderComponent` Vue component. The most important changes are:

### Updates to `UpdateArtwork` command:

* Added import for `NotificationSetting` in `artwork/Core/Console/Commands/UpdateArtwork.php` to manage notification settings.
* Enhanced the `handle` method to update notification settings for 'NOTIFICATION_ROOM_ANSWER' with a new title and description.

### Changes to `ProjectHeaderComponent`:

* Modified the project tab display logic in `resources/js/Pages/Projects/Tab/Components/ProjectHeaderComponent.vue` to directly use `tab.name` instead of translating it.