### PR TITLE
Update UpdateOrCreateProjectRelevantColumn.php

### DIFF
--- a/database/seeders/UpdateOrCreateProjectRelevantColumn.php
+++ b/database/seeders/UpdateOrCreateProjectRelevantColumn.php
@@ -25,8 +25,8 @@ class UpdateOrCreateProjectRelevantColumn extends Seeder
         $projects = Project::all();
         foreach ($projects as $project) {
             if ($project->is_group) {
-                $table = $project->table;
-                $column = $table->columns()->where('type', 'project_relevant_column')->first();
+                $table = $project?->table;
+                $column = $table?->columns()->where('type', 'project_relevant_column')->first();
 
                 if (!$column) {
                     $newColumn = $this->columnService->createColumnInTable(
@@ -67,11 +67,11 @@ class UpdateOrCreateProjectRelevantColumn extends Seeder
                 }
             } else {
                 // set last column to relevant_for_project_groups if no column is relevant_for_project_groups
-                $table = $project->table;
-                $columns = $table->columns()->get();
-                $lastColumn = $columns->last();
+                $table = $project?->table;
+                $columns = $table?->columns()->get();
+                $lastColumn = $columns?->last();
 
-                if (!$lastColumn->relevant_for_project_groups) {
+                if (!$lastColumn?->relevant_for_project_groups && $lastColumn) {
                     $lastColumn->update([
                         'relevant_for_project_groups' => true
                     ]);


### PR DESCRIPTION
This pull request includes changes to the `database/seeders/UpdateOrCreateProjectRelevantColumn.php` file to improve the robustness of the code by using the safe navigation operator. This ensures that the code does not throw errors when encountering null values.

Key changes include:

* [`database/seeders/UpdateOrCreateProjectRelevantColumn.php`](diffhunk://#diff-eca922469bec563027a7bc8b177404df75804d136fc6a593e07fdba692f63b84L28-R29): Modified the `$project->table` and `$table->columns()` calls to use the safe navigation operator (`?->`) to handle potential null values safely. [[1]](diffhunk://#diff-eca922469bec563027a7bc8b177404df75804d136fc6a593e07fdba692f63b84L28-R29) [[2]](diffhunk://#diff-eca922469bec563027a7bc8b177404df75804d136fc6a593e07fdba692f63b84L70-R74)