### PR TITLE
All Inputs

### DIFF
--- a/resources/js/Layouts/Components/AddCraftsModal.vue
+++ b/resources/js/Layouts/Components/AddCraftsModal.vue
@@ -4,12 +4,12 @@
         :title="$t('Craft')"
         :description="$t('Define the specifications of your trade.')"
     />
-    <div class="grid grid-cols-1 sm:grid-cols-7 gap-2 mb-10">
-        <div class="col-span-1 mt-5">
+    <div class="grid grid-cols-1 sm:grid-cols-7 gap-4 mb-4">
+        <div class="col-span-1">
             <ColorPickerComponent :color="craft.color" @updateColor="addColor"/>
         </div>
         <div class="col-span-3">
-            <TextInputComponent
+            <BaseInput
                 :label="$t('Name of the craft') + '*'"
                 v-model="craft.name"
                 id="name"
@@ -17,7 +17,7 @@
             />
         </div>
         <div class="col-span-3">
-            <TextInputComponent
+            <BaseInput
                 :label="$t('Abbreviation') + '*'"
                 v-model="craft.abbreviation"
                 :maxlength="3"
@@ -27,7 +27,7 @@
         </div>
     </div>
     <div class="">
-        <NumberInputComponent
+        <BaseInput type="number"
                v-model="craft.notify_days"
                :maxlength="3"
                required
@@ -63,7 +63,7 @@
         <Listbox as="div">
             <div class="relative mt-2">
                 <ListboxButton class="menu-button">
-                    <span class="block truncate text-left pl-3">
+                    <span class="block truncate text-left">
                         {{ $t('Select users')}}
                     </span>
                     <span class="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
@@ -123,7 +123,7 @@
         <Listbox as="div">
             <div class="relative mt-2">
                 <ListboxButton class="menu-button">
-                    <span class="block truncate text-left pl-3">
+                    <span class="block truncate text-left">
                         {{ $t('Select users')}}
                     </span>
                     <span class="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
@@ -238,11 +238,13 @@ import TextInputComponent from "@/Components/Inputs/TextInputComponent.vue";
 import NumberInputComponent from "@/Components/Inputs/NumberInputComponent.vue";
 import TinyPageHeadline from "@/Components/Headlines/TinyPageHeadline.vue";
 import UserSearch from "@/Components/SearchBars/UserSearch.vue";
+import BaseInput from "@/Artwork/Inputs/BaseInput.vue";
 
 export default defineComponent({
     name: "AddCraftsModal",
     mixins: [IconLib],
     components: {
+        BaseInput,
         UserSearch,
         TinyPageHeadline,
         NumberInputComponent,

--- a/resources/js/Layouts/Components/ProjectSettingsItem.vue
+++ b/resources/js/Layouts/Components/ProjectSettingsItem.vue
@@ -6,19 +6,20 @@
         </div>
     </div>
     <div class="mt-8 flex w-full flex-wrap gap-x-1">
-        <div class="justify-content-center relative items-center flex cursor-pointer rounded-full focus:outline-none mt-5">
+        <div class="justify-content-center relative items-center flex cursor-pointer rounded-full focus:outline-none">
             <ColorPickerComponent @update-color="UpdateColor"  />
         </div>
 
         <div class="relative flex max-w-lg w-full">
-            <TextInputComponent :id="inputLabel" v-model="input" :label="inputLabel" @keyup.enter="add" />
-            <div class="m-2 -ml-8 -mt-1 absolute top-6 right-0">
-                <button
-                    :class="[input === '' ? 'bg-secondary': 'bg-artwork-buttons-create hover:bg-artwork-buttons-hover focus:outline-none', 'rounded-full mt-2 ml-1 items-center text-sm p-1 border border-transparent uppercase shadow-sm text-white']"
-                    @click="add" :disabled="!input">
-                    <CheckIcon class="h-5 w-5"></CheckIcon>
-                </button>
-            </div>
+            <BaseInput :id="inputLabel" v-model="input" :label="inputLabel" @keyup.enter="add" />
+
+        </div>
+        <div class="">
+            <button
+                :class="[input === '' ? 'bg-secondary': 'bg-artwork-buttons-create hover:bg-artwork-buttons-hover focus:outline-none', 'rounded-full mt-2 ml-1 items-center text-sm p-1 border border-transparent uppercase shadow-sm text-white']"
+                @click="add" :disabled="!input">
+                <CheckIcon class="h-5 w-5"></CheckIcon>
+            </button>
         </div>
         <div class="flex flex-wrap w-full max-w-xl mt-2">
             <div v-if="itemStyle === 'tag'">
@@ -37,10 +38,12 @@ import {useForm} from "@inertiajs/vue3";
 import ColorPickerComponent from "@/Components/Globale/ColorPickerComponent.vue";
 import EditableTagComponent from "@/Components/Tags/EditableTagComponent.vue";
 import TextInputComponent from "@/Components/Inputs/TextInputComponent.vue";
+import BaseInput from "@/Artwork/Inputs/BaseInput.vue";
 
 export default {
     name: "ProjectSettingsItem",
     components: {
+        BaseInput,
         TextInputComponent,
         EditableTagComponent,
         ColorPickerComponent,

--- a/resources/js/Layouts/Components/ShiftQualificationModal.vue
+++ b/resources/js/Layouts/Components/ShiftQualificationModal.vue
@@ -41,7 +41,7 @@
                         </transition>
                     </Menu>-->
                     <div class="w-full">
-                        <TextInputComponent
+                        <BaseInput
                             no-margin-top
                             id="name"
                             v-model="this.shiftQualificationForm.name"
@@ -86,6 +86,7 @@ import BaseModal from "@/Components/Modals/BaseModal.vue";
 import TextInputComponent from "@/Components/Inputs/TextInputComponent.vue";
 import ModalHeader from "@/Components/Modals/ModalHeader.vue";
 import IconSelector from "@/Components/Icon/IconSelector.vue";
+import BaseInput from "@/Artwork/Inputs/BaseInput.vue";
 const shiftQualificationIcons = [
     {iconName: 'user-icon'},
     {iconName: 'academic-cap-icon'},
@@ -102,6 +103,7 @@ const shiftQualificationIcons = [
 export default defineComponent({
     name: 'ShiftQualificationModal',
     components: {
+        BaseInput,
         IconSelector,
         ModalHeader,
         TextInputComponent,

--- a/resources/js/Pages/BudgetSettingsAccountManagement/Index.vue
+++ b/resources/js/Pages/BudgetSettingsAccountManagement/Index.vue
@@ -29,14 +29,14 @@
             <div class="headline3 mb-5">{{ $t('Selectable accounts') }}</div>
             <div class="flex flex-row space-x-5 items-center">
                 <div class="w-96">
-                    <TextInputComponent
+                    <BaseInput
                         :label="$t('Account number')"
                         v-model="this.accountForm.account_number"
                         id="account_number"
                     />
                 </div>
                 <div class="w-96">
-                    <TextInputComponent
+                    <BaseInput
                         :label="$t('Description')"
                         v-model="this.accountForm.title"
                         id="title"
@@ -64,14 +64,14 @@
             <div class="headline3 mb-5">{{ $t('Selectable cost units') }}</div>
             <div class="flex flex-row space-x-5 items-center">
                 <div class="w-96">
-                    <TextInputComponent
+                    <BaseInput
                         :label="$t('Cost unit number')"
                         v-model="this.costUnitForm.cost_unit_number"
                         id="cost_unit_number"
                     />
                 </div>
                 <div class="w-96">
-                    <TextInputComponent
+                    <BaseInput
                         :label="$t('Description')"
                         v-model="this.costUnitForm.title"
                         id="costUnitFormTitle"
@@ -98,7 +98,7 @@
                             />
                         </div>
                         <div v-else class="flex items-center w-64">
-                            <TextInputComponent
+                            <BaseInput
                                 v-model="this.accountSearchQuery"
                                 :label="$t('Search account')"
                                 id="accountSearchQuery"
@@ -128,14 +128,14 @@
                         <!-- if account is edited -->
                         <div v-if="this.accountIdToEdit === account.id" class="flex flex-row items-center mt-5">
                             <span class="w-56 mr-2">
-                                <TextInputComponent
+                                <BaseInput
                                     v-model="this.editAccountForm.account_number"
                                     :label="this.editAccountForm.account_number"
                                     id="account_number"
                                 />
                             </span>
                             <span class="w-96 mr-2">
-                                <TextInputComponent
+                                <BaseInput
                                     v-model="this.editAccountForm.title"
                                     :label="this.editAccountForm.title"
                                     id="title"
@@ -192,7 +192,7 @@
                             />
                         </div>
                         <div v-else class="flex items-center w-64">
-                            <TextInputComponent
+                            <BaseInput
                                 v-model="this.costUnitSearchQuery"
                                 :label="$t('Search cost center')"
                                 id="costUnitSearchQuery"
@@ -218,14 +218,14 @@
                         <!-- if cost_unit is edited -->
                         <div v-if="this.costUnitIdToEdit === cost_unit.id" class="flex flex-row items-center mt-5">
                             <span class="w-56 mr-2">
-                                <TextInputComponent
+                                <BaseInput
                                     v-model="this.editCostUnitForm.cost_unit_number"
                                     :label="this.editCostUnitForm.cost_unit_number"
                                     id="cost_unit_number"
                                 />
                             </span>
                             <span class="w-96">
-                                <TextInputComponent
+                                <BaseInput
                                     v-model="this.editCostUnitForm.title"
                                     :label="this.editCostUnitForm.title"
                                     id="editCostUnitFormTitle"
@@ -290,10 +290,12 @@ import ErrorComponent from "@/Layouts/Components/ErrorComponent.vue";
 import SuccessModal from "@/Layouts/Components/General/SuccessModal.vue";
 import IconLib from "@/Mixins/IconLib.vue";
 import TextInputComponent from "@/Components/Inputs/TextInputComponent.vue";
+import BaseInput from "@/Artwork/Inputs/BaseInput.vue";
 
 export default defineComponent({
     mixins: [IconLib],
     components: {
+        BaseInput,
         TextInputComponent,
         SuccessModal,
         ErrorComponent,

--- a/resources/js/Pages/ChecklistTemplates/Create.vue
+++ b/resources/js/Pages/ChecklistTemplates/Create.vue
@@ -10,7 +10,7 @@
                 </div>
                 <div class="flex mt-8">
                     <div class="max-w-2xl w-full">
-                        <TextInputComponent
+                        <BaseInput
                             id="teamName"
                             v-model="templateForm.name"
                             :label="$t('Name of the checklist template')"/>
@@ -101,13 +101,13 @@
                         :title="$t('New task')"
                     />
                     <form @submit.prevent="addTaskToTemplate" class="grid grid-cols-1 gap-4">
-                        <TextInputComponent
+                        <BaseInput
                             id="task_name"
                             v-model="newTaskName"
                             :label="$t('Task')"
                             required
                         />
-                        <TextareaComponent
+                        <BaseTextarea
                             :label="$t('Comment')"
                             v-model="newTaskDescription"
                             id="newTaskDescription"
@@ -180,12 +180,16 @@ import TextInputComponent from "@/Components/Inputs/TextInputComponent.vue";
 import UserSearch from "@/Components/SearchBars/UserSearch.vue";
 import ModalHeader from "@/Components/Modals/ModalHeader.vue";
 import TextareaComponent from "@/Components/Inputs/TextareaComponent.vue";
+import BaseInput from "@/Artwork/Inputs/BaseInput.vue";
+import BaseTextarea from "@/Artwork/Inputs/BaseTextarea.vue";
 
 export default {
     mixins: [Permissions],
     name: "Template Create",
     props: [],
     components: {
+        BaseTextarea,
+        BaseInput,
         TextareaComponent,
         ModalHeader,
         UserSearch,

--- a/resources/js/Pages/CommunicationAndLegal/Index.vue
+++ b/resources/js/Pages/CommunicationAndLegal/Index.vue
@@ -11,56 +11,56 @@
         <div class="grid grid-cols-1 gap-4 mt-10 max-w-lg">
             <div class="">
                 <div class="sm:col-span-3">
-                    <TextInputComponent @focusout="updateCommunicationAndLegal" v-model="mailForm.page_title" id="page_title" :label="$t('Page Title')"/>
+                    <BaseInput @focusout="updateCommunicationAndLegal" v-model="mailForm.page_title" id="page_title" :label="$t('Page Title')"/>
                 </div>
             </div>
             <div class="">
                 <div class="sm:col-span-3">
-                    <TextInputComponent @focusout="updateCommunicationAndLegal" v-model="mailForm.businessName" id="businessName" :label="$t('Our Organization')"/>
+                    <BaseInput @focusout="updateCommunicationAndLegal" v-model="mailForm.businessName" id="businessName" :label="$t('Our Organization')"/>
                 </div>
             </div>
             <div class="">
                 <div class="sm:col-span-3">
-                    <TextInputComponent @focusout="updateCommunicationAndLegal" v-model="mailForm.impressumLink" id="impressumLink" :label="$t('Link to Legal Notice')"/>
+                    <BaseInput @focusout="updateCommunicationAndLegal" v-model="mailForm.impressumLink" id="impressumLink" :label="$t('Link to Legal Notice')"/>
                     <span v-if="showInvalidImpressumLinkErrorText"
-                          class="errorText">
+                          class="text-red-500 text-xs mt-1">
                         {{ $t('Invalid URL (Example: https://google.com)') }}
                     </span>
                 </div>
             </div>
             <div class="">
                 <div class="sm:col-span-3">
-                    <TextInputComponent @focusout="updateCommunicationAndLegal" v-model="mailForm.privacyLink" id="privacyLink" :label="$t('Link to Privacy Policy')"/>
+                    <BaseInput @focusout="updateCommunicationAndLegal" v-model="mailForm.privacyLink" id="privacyLink" :label="$t('Link to Privacy Policy')"/>
                     <span v-if="showInvalidPrivacyLinkErrorText"
-                          class="errorText">
+                          class="text-red-500 text-xs mt-1">
                         {{ $t('Invalid URL (Example: https://google.com)') }}
                     </span>
                 </div>
             </div>
             <div>
                 <div class="sm:col-span-3">
-                    <TextInputComponent id="invitationEmail"
+                    <BaseInput id="invitationEmail"
                                         v-model="mailForm.invitationEmail"
                                         :label="$t('Invitation Email')"
                                         @focusout="updateCommunicationAndLegal"/>
                     <span v-if="showInvalidInvitationEmailAdressErrorText"
-                          class="errorText">
+                          class="text-red-500 text-xs mt-1">
                         {{ $t('Invalid Email Address') }}
                     </span>
                 </div>
             </div>
             <div>
                 <div class="sm:col-span-3">
-                    <TextInputComponent @focusout="updateCommunicationAndLegal" v-model="mailForm.businessEmail" id="businessEmail" :label="$t('Business Email')"/>
+                    <BaseInput @focusout="updateCommunicationAndLegal" v-model="mailForm.businessEmail" id="businessEmail" :label="$t('Business Email')"/>
                     <span v-if="showInvalidBusinessEmailAddressErrorText"
-                          class="errorText">
+                          class="text-red-500 text-xs mt-1">
                         {{ $t('Invalid Email Address') }}
                     </span>
                 </div>
             </div>
             <div>
                 <div class="sm:col-span-8">
-                    <TextareaComponent
+                    <BaseInput
                         :label="$t('Email-Footer')"
                         v-model="mailForm.emailFooter"
                         @focusout="updateCommunicationAndLegal"
@@ -80,9 +80,11 @@ import ToolSettingsHeader from "@/Pages/ToolSettings/ToolSettingsHeader.vue";
 import FormButton from "@/Layouts/Components/General/Buttons/FormButton.vue";
 import TextInputComponent from "@/Components/Inputs/TextInputComponent.vue";
 import TextareaComponent from "@/Components/Inputs/TextareaComponent.vue";
+import BaseInput from "@/Artwork/Inputs/BaseInput.vue";
 
 export default defineComponent({
     components: {
+        BaseInput,
         TextareaComponent,
         TextInputComponent,
         FormButton,

--- a/resources/js/Pages/Interfaces/Index.vue
+++ b/resources/js/Pages/Interfaces/Index.vue
@@ -30,13 +30,13 @@
             </div>
         </div>
         <div class="w-1/2 mt-4 grid grid-cols-1 gap-4">
-            <TextInputComponent v-model="this.sageForm.host" :label="$t('Host')" id="host" />
-            <div class="errorText" v-if="showHostErrorText">{{ $t('The host must be specified.') }}</div>
-            <TextInputComponent v-model="this.sageForm.endpoint" id="endpoint" :label="$t('Endpoint')"/>
-            <div class="errorText" v-if="showEndpointErrorText">{{ $t('The end point must be specified.') }}</div>
-            <TextInputComponent v-model="this.sageForm.user" id="user" :label="$t('User')"/>
-            <div class="errorText" v-if="showUserErrorText">{{ $t('The user must be specified.') }}</div>
-            <TextInputComponent type="password"
+            <BaseInput v-model="this.sageForm.host" :label="$t('Host')" id="host" />
+            <div class="text-red-500 text-xs mt-1" v-if="showHostErrorText">{{ $t('The host must be specified.') }}</div>
+            <BaseInput v-model="this.sageForm.endpoint" id="endpoint" :label="$t('Endpoint')"/>
+            <div class="text-red-500 text-xs mt-1" v-if="showEndpointErrorText">{{ $t('The end point must be specified.') }}</div>
+            <BaseInput v-model="this.sageForm.user" id="user" :label="$t('User')"/>
+            <div class="text-red-500 text-xs mt-1" v-if="showUserErrorText">{{ $t('The user must be specified.') }}</div>
+            <BaseInput type="password"
                    v-model="this.sageForm.password"
                    :label="$t('Password')"
                    id="password"
@@ -52,23 +52,24 @@
                     </div>
                     <span>{{ $t('Query data from this booking date') }}&nbsp;</span>
                     <div class="w-72 ml-2">
-                        <DateInputComponent
+                        <BaseInput type="date"
                             v-model="this.sageForm.bookingDate"
                             label="tt.mm.yyyy"
                             id="bookingDate"
                         />
                     </div>
                 </div>
-                <div class="flex items-center justify-end">
+                <div class="flex items-center justify-end gap-x-3">
                     <span>{{ $t('Query daily at') }}&nbsp;</span>
-                    <TimeInputComponent
-                        v-model="this.sageForm.fetchTime"
-                        style="width:82px;"
-                        label="hh:mm"
-                        id=""
-                    />
+                    <div class="w-28">
+                        <BaseInput type="time"
+                                   v-model="this.sageForm.fetchTime"
+                                   label="hh:mm"
+                                   id=""
+                        />
+                    </div>
                 </div>
-                <div class="flex items-center justify-end">
+                <div class="flex items-center justify-end gap-x-3">
                     <label for="sageEnabled">{{ $t('Interface enabled') }}&nbsp;</label>
                     <input type="checkbox"
                            id="sageEnabled"
@@ -88,7 +89,7 @@
             <div v-if="!this.sageInterfaceIsConfigured()" class="errorText">{{ $t('Please configure the Sage interface first.') }}</div>
             <div class="flex flex-row items-center space-x-4">
                 <div class="w-96">
-                    <DateInputComponent
+                    <BaseInput type="date"
                         label="tt.mm.yyyy"
                         id="specificDayImportDate"
                         v-model="this.specificDayImportDate"
@@ -175,9 +176,11 @@ import DateInputComponent from "@/Components/Inputs/DateInputComponent.vue";
 import TimeInputComponent from "@/Components/Inputs/TimeInputComponent.vue";
 import {IconDragDrop} from "@tabler/icons-vue";
 import draggable from "vuedraggable";
+import BaseInput from "@/Artwork/Inputs/BaseInput.vue";
 
 export default defineComponent({
     components: {
+        BaseInput,
         IconDragDrop,
         TimeInputComponent,
         DateInputComponent,

--- a/resources/js/Pages/InventorySetting/Components/AddEditArticlePropertyModal.vue
+++ b/resources/js/Pages/InventorySetting/Components/AddEditArticlePropertyModal.vue
@@ -10,14 +10,14 @@
             <form @submit.prevent="addEditProperty">
                 <div class="grid grid-cols-1 md:grid-cols-4 gap-4">
                     <div class="col-span-full">
-                        <TextInputComponent
+                        <BaseInput
                             id="name" v-model="propertyForm.name"
                             :label="$t('Name')"
                         />
                     </div>
 
                     <div class="col-span-full">
-                        <TextareaComponent
+                        <BaseTextarea
                             id="description"
                             v-model="propertyForm.tooltip_text"
                             :label="$t('Tooltip text')"
@@ -54,8 +54,8 @@
 
                     <div v-if="selectedType.type === 'selection'" class="col-span-full">
                         <div v-for="(value, index) in propertyForm.select_values" :key="index" class="flex gap-3 items-center mb-2">
-                            <TextInputComponent
-                                id="select_value"
+                            <BaseInput
+                                :id="'select_value' + index"
                                 v-model="propertyForm.select_values[index]"
                                 :label="$t('Selection value {index}', {index: index + 1})"
                             />
@@ -138,6 +138,8 @@ import TextareaComponent from "@/Components/Inputs/TextareaComponent.vue";
 import {Listbox, ListboxButton, ListboxLabel, ListboxOption, ListboxOptions} from "@headlessui/vue";
 import {ref} from "vue";
 import FormButton from "@/Layouts/Components/General/Buttons/FormButton.vue";
+import BaseInput from "@/Artwork/Inputs/BaseInput.vue";
+import BaseTextarea from "@/Artwork/Inputs/BaseTextarea.vue";
 
 const props = defineProps({
     property: {

--- a/resources/js/Pages/InventorySetting/Components/AddEditCategoryModal.vue
+++ b/resources/js/Pages/InventorySetting/Components/AddEditCategoryModal.vue
@@ -12,7 +12,7 @@
                 <div class="grid grid-cols-1 gap-4 mb-8">
                     <div>
                         <div>
-                            <TextInputComponent
+                            <BaseInput
                                 id="name" v-model="categoryForm.name"
                                 :label="$t('Category Name')"
                                 required
@@ -126,8 +126,8 @@
                                     <div class="grid grid-cols-1 gap-4 mb-8">
                                         <div>
                                             <div>
-                                                <TextInputComponent
-                                                    id="name" v-model="subCategory.name"
+                                                <BaseInput
+                                                    :id="'subName' + index" v-model="subCategory.name"
                                                     :label="$t('Sub-Category Name')"
                                                     required
                                                 />
@@ -229,6 +229,7 @@ import FormButton from "@/Layouts/Components/General/Buttons/FormButton.vue";
 import {computed, onMounted, ref} from "vue";
 import TinyPageHeadline from "@/Components/Headlines/TinyPageHeadline.vue";
 import {Disclosure, DisclosureButton, DisclosurePanel} from "@headlessui/vue";
+import BaseInput from "@/Artwork/Inputs/BaseInput.vue";
 
 const props = defineProps({
     category: {

--- a/resources/js/Pages/InventorySetting/Index.vue
+++ b/resources/js/Pages/InventorySetting/Index.vue
@@ -9,7 +9,7 @@
                 <Listbox as="div">
                     <div class="relative mt-2 w-1/2">
                         <ListboxButton class="menu-button">
-                            <span class="block truncate text-left pl-3">{{$t('Select Event Types')}}</span>
+                            <span class="block truncate text-left">{{$t('Select Event Types')}}</span>
                             <span class="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
                                     <IconChevronDown  stroke-width="1.5" class="h-5 w-5 text-primary" aria-hidden="true"/>
                                 </span>

--- a/resources/js/Pages/MoneySources/MoneySourceSettings.vue
+++ b/resources/js/Pages/MoneySources/MoneySourceSettings.vue
@@ -18,7 +18,7 @@
                                     <!-- Finanzierungsquellenkategorien -->
                                     <div class="mt-8 mr-10 flex items-center gap-4">
                                         <div class="relative w-72">
-                                            <TextInputComponent
+                                            <BaseInput
                                                 v-on:keyup.enter=addMoneySourceCategory
                                                 id="moneySourceCategory"
                                                    v-model="moneySourceCategoryInput"
@@ -29,14 +29,14 @@
 
                                         <div class="">
                                             <button
-                                                :class="[moneySourceCategoryInput === '' ? 'bg-secondary': 'bg-artwork-buttons-create hover:bg-artwork-buttons-hover focus:outline-none', 'rounded-full mt-2 ml-1 items-center text-sm p-1 border border-transparent uppercase shadow-sm text-white']"
+                                                :class="[moneySourceCategoryInput === '' ? 'bg-secondary': 'bg-artwork-buttons-create hover:bg-artwork-buttons-hover focus:outline-none', 'rounded-full ml-1 items-center text-sm p-1 border border-transparent uppercase shadow-sm text-white']"
                                                 @click="addMoneySourceCategory" :disabled="!moneySourceCategoryInput">
                                                 <IconCheck stroke-width="1.5" class="h-5 w-5"></IconCheck>
                                             </button>
                                         </div>
                                     </div>
 
-                                    <div class="mt-2 mr-10 flex flex-wrap">
+                                    <div class="mr-10 mt-5 flex flex-wrap">
                                         <span v-for="(category,index) in moneySourceCategories"
                                               class="rounded-full items-center font-medium text-tagText
                                             border bg-tagBg border-tag px-3 text-sm mr-1 mb-1 h-8 inline-flex">
@@ -77,10 +77,12 @@ import JetDialogModal from "@/Jetstream/DialogModal.vue";
 import ConfirmationComponent from "@/Layouts/Components/ConfirmationComponent.vue";
 import IconLib from "@/Mixins/IconLib.vue";
 import TextInputComponent from "@/Components/Inputs/TextInputComponent.vue";
+import BaseInput from "@/Artwork/Inputs/BaseInput.vue";
 
 export default defineComponent({
     mixins: [Permissions, IconLib],
     components: {
+        BaseInput,
         TextInputComponent,
         ConfirmationComponent,
         JetDialogModal,

--- a/resources/js/Pages/Settings/Calendar/Index.vue
+++ b/resources/js/Pages/Settings/Calendar/Index.vue
@@ -22,7 +22,7 @@
 
                     <div class="grid grid-cols-1 md:grid-cols-2 gap-4 max-w-2xl mt-5">
                         <div>
-                            <TimeInputComponent
+                            <BaseInput type="time"
                                 id="start"
                                 v-model="tinyTimePeriod.start"
                                 :label="$t('Start-Time')"
@@ -31,7 +31,7 @@
                             />
                         </div>
                         <div>
-                            <TimeInputComponent
+                            <BaseInput type="time"
                                 id="end"
                                 v-model="tinyTimePeriod.end"
                                 :label="$t('End-Time')"
@@ -53,6 +53,7 @@ import TimeInputComponent from "@/Components/Inputs/TimeInputComponent.vue";
 import {useForm, usePage} from "@inertiajs/vue3";
 import {ref} from "vue";
 import VisualFeedback from "@/Components/Feedback/VisualFeedback.vue";
+import BaseInput from "@/Artwork/Inputs/BaseInput.vue";
 
 const props = defineProps({
     calendarSettings: {

--- a/resources/js/Pages/Settings/ComponentManagement/Components/ComponentModal.vue
+++ b/resources/js/Pages/Settings/ComponentManagement/Components/ComponentModal.vue
@@ -27,7 +27,7 @@
                     </div>
                 </Listbox>
                 <div>
-                    <TextInputComponent
+                    <BaseInput
                         :label="$t('Name of the component')"
                         v-model="componentName"
                         id="componentName"
@@ -42,28 +42,28 @@
                     </div>
                     <div v-for="(text, index) in textData">
                         <div class="" v-if="index === 'title'">
-                            <TextInputComponent
+                            <BaseInput
                                 :label="$t('Title')"
                                 v-model="textData.title"
                                 :id="index"
                             />
                         </div>
                         <div class="" v-if="index === 'label'">
-                            <TextInputComponent
+                            <BaseInput
                                 :label="$t('label')"
                                 v-model="textData.label"
                                 :id="index"
                             />
                         </div>
                         <div class="" v-if="index === 'text'">
-                            <TextInputComponent
+                            <BaseInput
                                 :label="$t('Text')"
                                 v-model="textData.text"
                                 :id="index"
                             />
                         </div>
                         <div class="" v-if="index === 'placeholder'">
-                            <TextInputComponent
+                            <BaseInput
                                 :label="$t('Placeholder')"
                                 v-model="textData.placeholder"
                                 :id="index"
@@ -101,7 +101,7 @@
                     <div v-if="textData.options?.length > 0" class="grid grid-cols-1 gap-4">
                         <div class="" v-for="(field, optionIndex) in textData.options">
                             <div>
-                                <TextInputComponent v-model="textData.options[optionIndex].value" :label="'Option (' + (optionIndex + 1) + ')'" :id="'option-' + optionIndex" />
+                                <BaseInput v-model="textData.options[optionIndex].value" :label="'Option (' + (optionIndex + 1) + ')'" :id="'option-' + optionIndex" />
                                 <span v-if="optionIndex !== 0" class="text-xs text-end underline underline-offset-2 text-artwork-buttons-create cursor-pointer" @click="removeOption(optionIndex)">
                                     Option ({{ optionIndex + 1 }}) {{ $t('Remove') }}
                                 </span>
@@ -112,13 +112,19 @@
                         </div>
                         <div v-if="textData.options[0].value">
                             <Listbox as="div" v-model="textData.selected">
-                                <ListboxLabel class="xsLight">{{ $t('Standard Option') }}</ListboxLabel>
                                 <div class="relative mt-2">
-                                    <ListboxButton class="relative w-full cursor-default rounded-md bg-white h-10 py-1.5 pl-3 pr-10 text-left text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:outline-none focus:ring-2 focus:ring-indigo-600 sm:text-sm sm:leading-6">
-                                        <span class="block truncate">{{ textData.selected }}</span>
-                                        <span class="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
-                                                  <IconChevronDown class="h-5 w-5 text-gray-400" aria-hidden="true" />
-                                                </span>
+                                    <ListboxButton class="menu-button-no-padding relative">
+                                        <div class="truncate">
+                                            <div class="top-2 left-4 absolute text-gray-500 text-xs">
+                                                {{ $t('Standard Option') }}
+                                            </div>
+                                            <div class="pt-6 pb-2 flex items-center gap-x-2">
+                                                <div class="truncate">
+                                                    {{ $t('Standard Option') }}
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <IconChevronDown class="h-5 w-5 text-primary" aria-hidden="true"/>
                                     </ListboxButton>
                                     <transition leave-active-class="transition ease-in duration-100" leave-from-class="opacity-100" leave-to-class="opacity-0">
                                         <ListboxOptions class="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm">
@@ -166,7 +172,7 @@
                         </div>
                         <div  v-if="this.modulePermissions.permission_type === 'allSeeSomeEdit'">
                             <div class="mt-4">
-                                <TextInputComponent
+                                <BaseInput
                                     :label="$t('Search for teams and/or users')"
                                     @input="this.searchUsersAndTeams()"
                                     v-model="this.userAndTeamsQuery"
@@ -244,7 +250,7 @@
                             <label for="someSeeSomeEdit" class="xsLight">Sehen darf nur:</label>
                         </div>
                         <div class="mt-4 relative" v-if="this.modulePermissions.permission_type === 'someSeeSomeEdit'">
-                            <TextInputComponent
+                            <BaseInput
                                 id="searchUsersAndTeams"
                                 :label="$t('Search for teams and/or users')"
                                 @input="this.searchUsersAndTeams()"
@@ -370,11 +376,13 @@ import {XCircleIcon} from "@heroicons/vue/solid";
 import ModalHeader from "@/Components/Modals/ModalHeader.vue";
 import TextInputComponent from "@/Components/Inputs/TextInputComponent.vue";
 import BaseModal from "@/Components/Modals/BaseModal.vue";
+import BaseInput from "@/Artwork/Inputs/BaseInput.vue";
 
 export default defineComponent({
     name: "ComponentModal",
     mixins: [IconLib],
     components: {
+        BaseInput,
         BaseModal,
         TextInputComponent,
         ModalHeader,

--- a/resources/js/Pages/Settings/Components/AddEditDayServiceModal.vue
+++ b/resources/js/Pages/Settings/Components/AddEditDayServiceModal.vue
@@ -17,7 +17,7 @@
                 <div class="flex items-center gap-x-3">
                     <IconSelector @update:modelValue="addIconToForm" :current-icon="dayServiceForm ? dayServiceForm.icon : null" />
                     <div class="w-full">
-                        <TextInputComponent
+                        <BaseInput
                             id="name"
                             no-margin-top
                             v-model="this.dayServiceForm.name"
@@ -66,11 +66,13 @@ import IconSelector from "@/Components/Icon/IconSelector.vue";
 import BaseModal from "@/Components/Modals/BaseModal.vue";
 import ModalHeader from "@/Components/Modals/ModalHeader.vue";
 import TextInputComponent from "@/Components/Inputs/TextInputComponent.vue";
+import BaseInput from "@/Artwork/Inputs/BaseInput.vue";
 
 export default {
     name: "AddEditDayServiceModal",
     mixins: [Permissions, IconLib],
     components: {
+        BaseInput,
         TextInputComponent,
         ModalHeader,
         BaseModal,

--- a/resources/js/Pages/Settings/Components/AddEditShiftTimePreset.vue
+++ b/resources/js/Pages/Settings/Components/AddEditShiftTimePreset.vue
@@ -8,6 +8,7 @@ import TextInputComponent from "@/Components/Inputs/TextInputComponent.vue";
 import ModalHeader from "@/Components/Modals/ModalHeader.vue";
 import TimeInputComponent from "@/Components/Inputs/TimeInputComponent.vue";
 import NumberInputComponent from "@/Components/Inputs/NumberInputComponent.vue";
+import BaseInput from "@/Artwork/Inputs/BaseInput.vue";
 
 const emit = defineEmits(['closed'])
 
@@ -50,7 +51,7 @@ const saveTimePreset = () => {
             />
             <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div class="col-span-2">
-                    <TextInputComponent
+                    <BaseInput
                            :label="$t('Name')"
                            v-model="newTimePreset.name"
                            id="name"
@@ -58,7 +59,7 @@ const saveTimePreset = () => {
                     />
                 </div>
                 <div>
-                    <TimeInputComponent
+                    <BaseInput type="time"
                            :label="$t('Start-Time')"
                            v-model="newTimePreset.start_time"
                            id="start_time"
@@ -66,7 +67,7 @@ const saveTimePreset = () => {
                     />
                 </div>
                 <div>
-                    <TimeInputComponent
+                    <BaseInput type="time"
                         :label="$t('End-Time')"
                         v-model="newTimePreset.end_time"
                         id="end_time"
@@ -74,7 +75,7 @@ const saveTimePreset = () => {
                     />
                 </div>
                 <div class="col-span-2">
-                    <NumberInputComponent
+                    <BaseInput type="number"
                         :label="$t('Length of break in minutes*')"
                         v-model="newTimePreset.break_time"
                         required

--- a/resources/js/Pages/Settings/Components/AddEditTabModal.vue
+++ b/resources/js/Pages/Settings/Components/AddEditTabModal.vue
@@ -6,11 +6,13 @@ import {XIcon} from "@heroicons/vue/solid";
 import {useForm} from "@inertiajs/vue3";
 import ModalHeader from "@/Components/Modals/ModalHeader.vue";
 import TextInputComponent from "@/Components/Inputs/TextInputComponent.vue";
+import BaseInput from "@/Artwork/Inputs/BaseInput.vue";
 
 export default {
     name: "AddEditTabModal",
     mixins: [IconLib],
     components: {
+        BaseInput,
         TextInputComponent,
         ModalHeader,
         FormButton,
@@ -80,7 +82,7 @@ export default {
                                     :description="tabToEdit ? $t('Edit tab name') : $t('Create a new tab')"
                                 />
                                 <div>
-                                    <TextInputComponent type="text" v-model="tabForm.name" label="Name" id="email" />
+                                    <BaseInput type="text" v-model="tabForm.name" label="Name" id="email" />
                                 </div>
                                 <div class="flex justify-between mt-5 items-center pr-4">
                                     <FormButton

--- a/resources/js/Pages/Settings/EventProperties/EventPropertyModal.vue
+++ b/resources/js/Pages/Settings/EventProperties/EventPropertyModal.vue
@@ -9,7 +9,7 @@
                     <IconSelector @update:modelValue="addIconToForm" :current-icon="eventPropertyToEdit ? eventPropertyToEdit.icon : null" />
                 </div>
                 <div class="w-full">
-                    <TextInputComponent
+                    <BaseInput
                         id="name"
                         v-model="eventPropertyForm.name"
                         label="Name"
@@ -39,6 +39,7 @@ import TextInputComponent from "@/Components/Inputs/TextInputComponent.vue";
 import FormButton from "@/Layouts/Components/General/Buttons/FormButton.vue";
 import {useForm} from "@inertiajs/vue3";
 import IconSelector from "@/Components/Icon/IconSelector.vue";
+import BaseInput from "@/Artwork/Inputs/BaseInput.vue";
 
 const props = defineProps({
         eventPropertyToEdit: {

--- a/resources/js/Pages/Settings/EventStatus/Components/AddEditEventStatusModal.vue
+++ b/resources/js/Pages/Settings/EventStatus/Components/AddEditEventStatusModal.vue
@@ -10,7 +10,7 @@
                     <ColorPickerComponent :color="eventStatus?.color" @updateColor="setColor" />
                 </div>
                 <div class="w-full">
-                    <TextInputComponent
+                    <BaseInput
                         id="name"
                         v-model="eventStatus.name"
                         label="Name"
@@ -57,6 +57,7 @@ import {useForm} from "@inertiajs/vue3";
 import TextInputComponent from "@/Components/Inputs/TextInputComponent.vue";
 import FormButton from "@/Layouts/Components/General/Buttons/FormButton.vue";
 import {Switch} from "@headlessui/vue";
+import BaseInput from "@/Artwork/Inputs/BaseInput.vue";
 
 const props = defineProps({
     eventStatusToEdit: {

--- a/resources/js/Pages/Settings/EventType/Components/Modals/AddEditEventTypModal.vue
+++ b/resources/js/Pages/Settings/EventType/Components/Modals/AddEditEventTypModal.vue
@@ -16,10 +16,10 @@
                     </div>
                 </div>
                 <div class="col-span-4">
-                    <TextInputComponent id="name" v-model="eventTypeForm.name" type="text" :label="$t('Event type name*')" required/>
+                    <BaseInput id="name" v-model="eventTypeForm.name" type="text" :label="$t('Event type name*')" required/>
                 </div>
                 <div class="col-span-full">
-                    <TextInputComponent
+                    <BaseInput
                         :label="$t('Abbreviation of the event type') + '*'"
                         v-model="eventTypeForm.abbreviation"
                         required
@@ -140,6 +140,7 @@ import UserSearch from "@/Components/SearchBars/UserSearch.vue";
 import {XIcon} from "@heroicons/vue/outline";
 import BaseAlertComponent from "@/Components/Alerts/BaseAlertComponent.vue";
 import {computed} from "vue";
+import BaseInput from "@/Artwork/Inputs/BaseInput.vue";
 
 const props = defineProps({
     eventType: {

--- a/resources/js/Pages/Settings/ProjectPrintLayout/Components/CreateOrUpdateProjectPrintLayoutModal.vue
+++ b/resources/js/Pages/Settings/ProjectPrintLayout/Components/CreateOrUpdateProjectPrintLayoutModal.vue
@@ -10,14 +10,14 @@
         <form @submit.prevent="createOrUpdate">
             <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
                 <div class="col-span-full">
-                    <TextInputComponent
+                    <BaseInput
                         id="name"
                         v-model="createOrUpdateForm.name"
                         :label="$t('Name')"
                     />
                 </div>
                 <div class="col-span-full">
-                    <TextInputComponent
+                    <BaseInput
                         id="description"
                         v-model="createOrUpdateForm.description"
                         :label="$t('Description')"
@@ -102,6 +102,7 @@ import TextInputComponent from "@/Components/Inputs/TextInputComponent.vue";
 import {Switch, SwitchGroup, SwitchLabel} from "@headlessui/vue";
 import FormButton from "@/Layouts/Components/General/Buttons/FormButton.vue";
 import AlertComponent from "@/Components/Alerts/AlertComponent.vue";
+import BaseInput from "@/Artwork/Inputs/BaseInput.vue";
 
 const props = defineProps({
     projectPrintLayout: {

--- a/resources/js/Pages/System/FileSettings/Index.vue
+++ b/resources/js/Pages/System/FileSettings/Index.vue
@@ -16,7 +16,7 @@
         <Listbox as="div">
           <div class="relative mt-2 w-1/2">
             <ListboxButton class="menu-button">
-              <span class="block truncate text-left pl-3">{{$t('Select file types')}}</span>
+              <span class="block truncate text-left">{{$t('Select file types')}}</span>
               <span class="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
                                     <IconChevronDown  stroke-width="1.5" class="h-5 w-5 text-primary" aria-hidden="true"/>
                                 </span>

--- a/resources/js/Pages/TimelinePreset/Components/AddEditTimelinePresetModal.vue
+++ b/resources/js/Pages/TimelinePreset/Components/AddEditTimelinePresetModal.vue
@@ -8,7 +8,7 @@
         <form @submit.prevent="updateOrCreate" class="w-full">
             <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div class="col-span-full">
-                    <TextInputComponent
+                    <BaseInput
                         id="name"
                         v-model="createOrUpdateForm.name"
                         :label="$t('Name of the template*')"
@@ -31,7 +31,7 @@
                    </div>
                </div>
                 <div class="col-span-full">
-                    <TextareaComponent
+                    <BaseTextarea
                         v-model="rawText"
                         id="rawText"
                         :label="$t('Enter your times here. Each line is interpreted as a separate entry.')"
@@ -85,6 +85,8 @@ import TinyPageHeadline from "@/Components/Headlines/TinyPageHeadline.vue";
 import FormButton from "@/Layouts/Components/General/Buttons/FormButton.vue";
 import TextInputComponent from "@/Components/Inputs/TextInputComponent.vue";
 import {useForm} from "@inertiajs/vue3";
+import BaseInput from "@/Artwork/Inputs/BaseInput.vue";
+import BaseTextarea from "@/Artwork/Inputs/BaseTextarea.vue";
 
 const props = defineProps({
     presetToEdit: {


### PR DESCRIPTION
This pull request includes a series of updates across multiple Vue components to replace the `TextInputComponent` with the new `BaseInput` component. This change aims to standardize the input components used across the application.

### Component Updates:

* `resources/js/Layouts/Components/AddCraftsModal.vue`:
  - Replaced `TextInputComponent` with `BaseInput` for various input fields. [[1]](diffhunk://#diff-174503506071eda5a094f42fccec714b024cda40a26eb36015f1efa0c345db84L7-R20) [[2]](diffhunk://#diff-174503506071eda5a094f42fccec714b024cda40a26eb36015f1efa0c345db84L30-R30) [[3]](diffhunk://#diff-174503506071eda5a094f42fccec714b024cda40a26eb36015f1efa0c345db84L66-R66) [[4]](diffhunk://#diff-174503506071eda5a094f42fccec714b024cda40a26eb36015f1efa0c345db84L126-R126) [[5]](diffhunk://#diff-174503506071eda5a094f42fccec714b024cda40a26eb36015f1efa0c345db84R241-R247)

* `resources/js/Layouts/Components/ProjectSettingsItem.vue`:
  - Updated the input fields to use `BaseInput` instead of `TextInputComponent`. [[1]](diffhunk://#diff-6897215592fa0b5e43b3214e6d5f9987c527f3c7b311c3bd30ec19f836ba4e22L9-L22) [[2]](diffhunk://#diff-6897215592fa0b5e43b3214e6d5f9987c527f3c7b311c3bd30ec19f836ba4e22R41-R46)

* `resources/js/Layouts/Components/ShiftQualificationModal.vue`:
  - Switched from `TextInputComponent` to `BaseInput` for input fields. [[1]](diffhunk://#diff-90c11c87f8eb1e03ccec05f162cd85fed22d81721b268347323aad4cbab055d4L44-R44) [[2]](diffhunk://#diff-90c11c87f8eb1e03ccec05f162cd85fed22d81721b268347323aad4cbab055d4R89) [[3]](diffhunk://#diff-90c11c87f8eb1e03ccec05f162cd85fed22d81721b268347323aad4cbab055d4R106)

* `resources/js/Pages/BudgetSettingsAccountManagement/Index.vue`:
  - Replaced `TextInputComponent` with `BaseInput` for account and cost unit management input fields. [[1]](diffhunk://#diff-a7b00432928210c0c6c2fc217203ad280c8a1c054b7acb29e909d02817925b6cL32-R39) [[2]](diffhunk://#diff-a7b00432928210c0c6c2fc217203ad280c8a1c054b7acb29e909d02817925b6cL67-R74) [[3]](diffhunk://#diff-a7b00432928210c0c6c2fc217203ad280c8a1c054b7acb29e909d02817925b6cL101-R101) [[4]](diffhunk://#diff-a7b00432928210c0c6c2fc217203ad280c8a1c054b7acb29e909d02817925b6cL131-R138) [[5]](diffhunk://#diff-a7b00432928210c0c6c2fc217203ad280c8a1c054b7acb29e909d02817925b6cL195-R195) [[6]](diffhunk://#diff-a7b00432928210c0c6c2fc217203ad280c8a1c054b7acb29e909d02817925b6cL221-R228) [[7]](diffhunk://#diff-a7b00432928210c0c6c2fc217203ad280c8a1c054b7acb29e909d02817925b6cR293-R298)

* `resources/js/Pages/ChecklistTemplates/Create.vue`:
  - Updated to use `BaseInput` and `BaseTextarea` in place of `TextInputComponent` and `TextareaComponent`. [[1]](diffhunk://#diff-6f30fdf9a4fc3775c8d14a7749a9a3cfb554c1ca5b8a67fc83b02662035e7c36L13-R13) [[2]](diffhunk://#diff-6f30fdf9a4fc3775c8d14a7749a9a3cfb554c1ca5b8a67fc83b02662035e7c36L104-R110) [[3]](diffhunk://#diff-6f30fdf9a4fc3775c8d14a7749a9a3cfb554c1ca5b8a67fc83b02662035e7c36R183-R192)

* `resources/js/Pages/CommunicationAndLegal/Index.vue`:
  - Changed input fields from `TextInputComponent` to `BaseInput`. [[1]](diffhunk://#diff-a2955f1df1a46d566278c86f1bfcf3346f3c0a3de71e56fd5f9eaae5b9464878L14-R63) [[2]](diffhunk://#diff-a2955f1df1a46d566278c86f1bfcf3346f3c0a3de71e56fd5f9eaae5b9464878R83-R87)