### PR TITLE
Add chat push notification toggle for users

### DIFF
--- a/artwork/Modules/Chat/Http/Controllers/ChatController.php
+++ b/artwork/Modules/Chat/Http/Controllers/ChatController.php
@@ -352,4 +352,13 @@ class ChatController extends Controller
             return $ciphertext;
         }
     }
+
+    public function disableOrEnableChatNotifications(Request $request): void
+    {
+        /** @var User $user */
+        $user = $this->auth->user();
+
+        $enable = $request->boolean('enabled', true);
+        $user->update(['chat_push_notification' => $enable]);
+    }
 }

--- a/artwork/Modules/User/Models/User.php
+++ b/artwork/Modules/User/Models/User.php
@@ -237,6 +237,7 @@ class User extends Model implements
         'use_chat',
         'work_time_balance',
         'chat_popup_position',
+        'chat_push_notification'
     ];
 
     protected $casts = [
@@ -267,6 +268,7 @@ class User extends Model implements
         'daily_view' => 'boolean',
         'bulk_column_size' => 'array',
         'use_chat' => 'boolean',
+        'chat_push_notification' => 'boolean',
     ];
 
     protected $hidden = [

--- a/database/migrations/2025_09_18_145306_add_chat_push_notification_add_disable.php
+++ b/database/migrations/2025_09_18_145306_add_chat_push_notification_add_disable.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->boolean('chat_push_notification')->default(true);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('chat_push_notification');
+        });
+    }
+};

--- a/lang/de.json
+++ b/lang/de.json
@@ -3057,6 +3057,8 @@
     "Searching…": "Suche...",
     "Notes & booking": "Notizen & Buchung",
     "Add or edit working hours for the user": "Arbeitszeiten für die Nutzer*in hinzufügen oder bearbeiten",
-    "Please select a valid date.": "Bitte wähle ein gültiges Datum."
+    "Please select a valid date.": "Bitte wähle ein gültiges Datum.",
+    "Disable Notifications": "Benachrichtigungen deaktivieren",
+    "Enable Notifications": "Benachrichtigungen aktivieren"
 }
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -3051,5 +3051,7 @@
     "Searching…": "Searching…",
     "Notes & booking": "Notes & booking",
     "Add or edit working hours for the user": "Add or edit working hours for the user",
-    "Please select a valid date.": "Please select a valid date."
+    "Please select a valid date.": "Please select a valid date.",
+    "Disable Notifications": "Disable Notifications",
+    "Enable Notifications": "Enable Notifications"
 }

--- a/resources/js/Components/Chat/PopupChat.vue
+++ b/resources/js/Components/Chat/PopupChat.vue
@@ -1,6 +1,6 @@
 <template>
     <!-- Toasts bleiben global -->
-    <div aria-live="assertive" class="pointer-events-none fixed inset-0 flex items-end px-4 py-6 sm:items-start sm:p-6 z-50">
+    <div aria-live="assertive" class="pointer-events-none fixed inset-0 flex items-end px-4 py-6 sm:items-start sm:p-6 z-50" v-if="usePage().props.auth.user.chat_push_notification">
         <div class="flex w-full flex-col items-center space-y-4 sm:items-end">
             <ChatToastNotification
                 v-for="(toast, index) in toastMessages"
@@ -18,7 +18,7 @@
     <div :class="positionClass" :style="positionStyle" ref="chatRoot" data-chat-root>
         <div v-if="!isChatOpen">
             <div class="rounded-full shadow-lg bg-white p-2 cursor-pointer border border-gray-200 relative" @click="openChat">
-                <component is="IconBubbleText" class="size-10" />
+                <component :is="IconBubbleText" class="size-10" />
 
                 <span v-if="totalUnreadCount > 0" class="absolute inline-flex items-center w-6 h-6 -top-2 -right-2">
                     <!--<span class="absolute inline-flex h-full w-full animate-ping rounded-full bg-red-400 opacity-75"></span>-->
@@ -42,8 +42,19 @@
                                 <div v-if="!checkIfChatIsSelected" @click="openAddNewChat = true">
                                     <ToolTipComponent
                                         direction="top"
-                                        icon="IconPlus"
+                                        :icon="IconPlus"
                                         :tooltip-text="$t('Add new Chat')"
+                                        class="cursor-pointer p-1 hover:bg-gray-100 rounded transition-colors duration-200"
+                                        icon-class="size-5"
+                                    />
+                                </div>
+
+                                <!-- Change Chat position Button -->
+                                <div @click="enableOrDisablePushNotification">
+                                    <ToolTipComponent
+                                        direction="top"
+                                        :icon="usePage().props.auth.user.chat_push_notification ? IconBellOff : IconBell"
+                                        :tooltip-text="usePage().props.auth.user.chat_push_notification ? $t('Disable Notifications') : $t('Enable Notifications')"
                                         class="cursor-pointer p-1 hover:bg-gray-100 rounded transition-colors duration-200"
                                         icon-class="size-5"
                                     />
@@ -53,7 +64,7 @@
                                 <div @click="showPositionPicker = true">
                                     <ToolTipComponent
                                         direction="top"
-                                        icon="IconArrowsMove"
+                                        :icon="IconArrowsMove"
                                         :tooltip-text="$t('Change Chat position')"
                                         class="cursor-pointer p-1 hover:bg-gray-100 rounded transition-colors duration-200"
                                         icon-class="size-5"
@@ -61,7 +72,7 @@
                                 </div>
 
                                 <div class="" @click="closeChat">
-                                    <component is="IconX" class="size-5 cursor-pointer transition-colors duration-200 ease-in-out" aria-hidden="true" />
+                                    <component :is="IconX" class="size-5 cursor-pointer transition-colors duration-200 ease-in-out" aria-hidden="true" />
                                 </div>
                             </div>
                         </div>
@@ -71,7 +82,7 @@
                             <div v-if="!checkIfChatIsSelected" class="px-3 py-1">
                                 <div class="grid grid-cols-1">
                                     <input v-model="searchChat" type="text" name="account-number" id="account-number" class="col-start-1 border border-gray-200 row-start-1 block w-full rounded-md bg-white py-3 pr-10 pl-3 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-100 placeholder:text-gray-400 focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:pr-9 sm:text-sm/6" :placeholder="$t('Search in chats')" />
-                                    <component is="IconSearch" class="pointer-events-none col-start-1 row-start-1 mr-3 size-5 self-center justify-self-end text-gray-400 sm:size-4" aria-hidden="true" />
+                                    <component :is="IconSearch" class="pointer-events-none col-start-1 row-start-1 mr-3 size-5 self-center justify-self-end text-gray-400 sm:size-4" aria-hidden="true" />
                                 </div>
                             </div>
                             <div v-else class="bg-white px-4">
@@ -80,7 +91,7 @@
                                         <div class="mr-1 cursor-pointer" @click="goBackToChatList">
                                             <ToolTipComponent
                                                 direction="top"
-                                                icon="IconChevronLeft"
+                                                :icon="IconChevronLeft"
                                                 :tooltip-text="$t('Back to Chat List')"
                                             />
                                         </div>
@@ -100,12 +111,12 @@
                                             <div class="mr-1 cursor-pointer" @click="goBackToChatList">
                                                 <ToolTipComponent
                                                     direction="top"
-                                                    icon="IconChevronLeft"
+                                                    :icon="IconChevronLeft"
                                                     :tooltip-text="$t('Back to Chat List')"
                                                     use-translation
                                                 />
                                             </div>
-                                            <component is="IconUsersGroup" class="size-10 rounded-full object-cover p-3 bg-blue-50 text-blue-500 border border-blue-100" />
+                                            <component :is="IconUsersGroup" class="size-10 rounded-full object-cover p-3 bg-blue-50 text-blue-500 border border-blue-100" />
                                             <div class="ml-3">
                                                 <p class="text-sm text-gray-900">{{ chatPartner.name }}</p>
                                                 <p class="text-[9px] text-gray-500">{{ chatPartner.users.map((user) => user.full_name).join(', ') }}</p>
@@ -116,7 +127,7 @@
                                             <div @click="showRenameModal = true">
                                                 <ToolTipComponent
                                                     direction="top"
-                                                    icon="IconEdit"
+                                                    :icon="IconEdit"
                                                     :tooltip-text="$t('Rename Group Chat')"
                                                     class="cursor-pointer p-1 hover:bg-gray-100 rounded transition-colors duration-200 chat-tooltip-black-icon"
                                                     icon-size="size-4"
@@ -126,7 +137,7 @@
                                             <div @click="showDeleteConfirm = true">
                                                 <ToolTipComponent
                                                     direction="top"
-                                                    icon="IconTrash"
+                                                    :icon="IconTrash"
                                                     :tooltip-text="$t('Delete Group Chat')"
                                                     class="cursor-pointer p-1 hover:bg-gray-100 rounded transition-colors duration-200 chat-tooltip-black-icon"
                                                     icon-size="size-4"
@@ -140,7 +151,7 @@
                         <div v-if="isLoading">
                             <div class="flex items-center justify-center max-h-96 min-h-96 w-full h-full">
                                 <!-- loading -->
-                                <component is="IconLoaderQuarter" class="motion-safe:animate-spin" />
+                                <component :is="IconLoaderQuarter" class="motion-safe:animate-spin" />
                             </div>
                         </div>
                         <div v-else class="px-3">
@@ -167,7 +178,7 @@
                                         <div class="rounded-md bg-red-50 p-4 mb-5">
                                             <div class="flex items-center">
                                                 <div class="shrink-0">
-                                                    <component is="IconInfoSquareRoundedFilled" class="size-6 text-red-400" aria-hidden="true" />
+                                                    <component :is="IconInfoSquareRoundedFilled" class="size-6 text-red-400" aria-hidden="true" />
                                                 </div>
                                                 <div class="ml-3">
                                                     <p class="text-xs font-lexend font-medium text-red-800">
@@ -225,7 +236,7 @@
                                 @keyup.enter.exact="scrollToBottom"
                             />
                             <div @click="sendMessage" class="rounded-full p-2 bg-artwork-buttons-create cursor-pointer hover:bg-artwork-buttons-hover duration-200 ease-in-out transition-colors">
-                                <component is="IconBrandTelegram" class="size-4 cursor-pointer text-white" aria-hidden="true" />
+                                <PropertyIcon name="IconBrandTelegram" class="size-4 cursor-pointer text-white" aria-hidden="true" />
                             </div>
                         </div>
                     </div>
@@ -335,6 +346,16 @@ import {useUserStatus} from "@/Composeables/useUserStatus.js";
 import ToolTipComponent from "@/Components/ToolTips/ToolTipComponent.vue";
 import RenameGroupChatModal from "@/Components/Chat/Modals/RenameGroupChatModal.vue";
 import DeleteGroupChatModal from "@/Components/Chat/Modals/DeleteGroupChatModal.vue";
+import {
+    IconArrowsMove, IconBell, IconBellOff,
+    IconBubbleText,
+    IconChevronLeft,
+    IconEdit, IconInfoSquareRoundedFilled, IconLoaderQuarter, IconPlus,
+    IconSearch, IconTrash,
+    IconUsersGroup,
+    IconX
+} from "@tabler/icons-vue";
+import PropertyIcon from "@/Artwork/Icon/PropertyIcon.vue";
 const { getUserStatus } = useUserStatus()
 
 const props = defineProps({})
@@ -1021,6 +1042,24 @@ const handleChatDeleted = (chatId) => {
     chatPartner.value = null;
 };
 
+
+const enableOrDisablePushNotification = () => {
+    const payload = {
+
+    }
+
+    router.post(route('chat-system.toggle-push-notifications'),
+        {
+            enabled: !usePage().props.auth.user.chat_push_notification
+        }, {
+        onSuccess: (response) => {
+
+        },
+        onError: (error) => {
+            console.error("Fehler beim Umschalten der Push-Benachrichtigungen:", error);
+        }
+    });
+}
 
 
 

--- a/resources/js/Layouts/AppLayout.vue
+++ b/resources/js/Layouts/AppLayout.vue
@@ -18,7 +18,7 @@
                     <div class="ml-4 xsDark">{{ pushNotification.message }}</div>
                 </div>
                 <button type="button" class="-mt-4 mr-2">
-                    <component is="IconX" class="-mt-4 h-5 w-5 text-secondary hover:text-error relative"
+                    <component :is="IconX" class="-mt-4 h-5 w-5 text-secondary hover:text-error relative"
                            @click="closePushNotification(pushNotification.id)"/>
                 </button>
             </div>
@@ -43,6 +43,7 @@ import SubMenu from "@/Layouts/SubMenu.vue";
 import {defineAsyncComponent, onBeforeMount, onMounted, onUnmounted, ref, watchEffect} from "vue";
 import {reloadRolesAndPermissions} from "laravel-permission-to-vuejs";
 import {useI18n} from "vue-i18n";
+import {IconX} from "@tabler/icons-vue";
 const { locale } = useI18n();
 
 const props = defineProps({

--- a/routes/web.php
+++ b/routes/web.php
@@ -293,6 +293,10 @@ Route::group(['middleware' => ['auth:sanctum', 'verified']], function (): void {
     Route::patch('/users/{user}/chat/popup-settings', [UserController::class, 'updateChatPopupSettings'])
         ->name('user.chat.popup-settings');
 
+    // chat-system.toggle-push-notifications
+    Route::post('/users/chat/push-notifications', [ChatController::class, 'disableOrEnableChatNotifications'])
+        ->name('chat-system.toggle-push-notifications');
+
     Route::patch(
         '/users/{user}/permissions',
         [


### PR DESCRIPTION
Introduces a user setting to enable or disable chat push notifications. Adds a migration for the new 'chat_push_notification' field, updates backend and frontend logic to support toggling notifications, and provides related translations.