### PR TITLE
#timo icon fix

### DIFF
--- a/resources/js/Artwork/Contact/ArtworkSingleContact.vue
+++ b/resources/js/Artwork/Contact/ArtworkSingleContact.vue
@@ -8,8 +8,8 @@
         </div>
         <!-- Menu -->
         <BaseMenu has-no-offset white-menu-background>
-            <BaseMenuItem @click="showCreateOrUpdateContactModal = true" title="Edit" white-menu-background/>
-            <BaseMenuItem @click="showDeleteModal = true" title="Delete" icon="IconTrash" white-menu-background/>
+            <BaseMenuItem @click="showCreateOrUpdateContactModal = true" title="Edit" :icon="IconEdit" white-menu-background/>
+            <BaseMenuItem @click="showDeleteModal = true" title="Delete" :icon="IconTrash" white-menu-background/>
         </BaseMenu>
     </div>
     <dl class="-my-3 divide-y divide-gray-100 px-6 py-4 text-sm/6">
@@ -62,6 +62,7 @@ import BaseMenuItem from "@/Components/Menu/BaseMenuItem.vue";
 import BaseMenu from "@/Components/Menu/BaseMenu.vue";
 import {defineAsyncComponent, ref} from "vue";
 import {router} from "@inertiajs/vue3";
+import {IconEdit, IconTrash} from "@tabler/icons-vue";
 
 const props = defineProps({
     contact: {

--- a/resources/js/Artwork/Feedback/NotificationToast.vue
+++ b/resources/js/Artwork/Feedback/NotificationToast.vue
@@ -26,7 +26,7 @@
                                     @click="visible = false"
                                     class="inline-flex rounded-md bg-white text-gray-400 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">
                                     <span class="sr-only">Schließen</span>
-                                    <component is="IconX" class="size-5" aria-hidden="true" />
+                                    <component :is="IconX" class="size-5" aria-hidden="true" />
                                 </button>
                             </div>
                         </div>
@@ -39,6 +39,7 @@
 
 <script setup>
 import { ref, watch } from 'vue'
+import {IconX} from "@tabler/icons-vue";
 
 const props = defineProps({
     show: Boolean,

--- a/resources/js/Artwork/Inputs/BaseInput.vue
+++ b/resources/js/Artwork/Inputs/BaseInput.vue
@@ -29,7 +29,7 @@
                 class="text-gray-500 hover:text-artwork-messages-error transition duration-200 ease-in-out"
                 :aria-label="$t ? $t('Clear input') : 'Clear input'"
             >
-                <component is="IconX" class="size-4" />
+                <component :is="IconX" class="size-4" />
             </button>
         </div>
 
@@ -39,7 +39,7 @@
             class="absolute right-1 top-0 bottom-0 flex items-center pr-2"
         >
             <div class="animate-spin">
-                <component is="IconLoader" class="size-4 text-gray-500" />
+                <component :is="IconLoader" class="size-4 text-gray-500" />
             </div>
         </div>
 
@@ -64,6 +64,7 @@
 
 <script setup>
 import { computed } from 'vue'
+import {IconX} from "@tabler/icons-vue";
 
 // v-model (Composition API)
 const model = defineModel({ default: '' })

--- a/resources/js/Components/Alerts/MultiAlertComponent.vue
+++ b/resources/js/Components/Alerts/MultiAlertComponent.vue
@@ -10,7 +10,7 @@
         <div class="rounded-md bg-red-50 p-4">
             <div class="flex">
                 <div class="shrink-0">
-                    <component is="IconXboxX" class="size-5 text-red-400" aria-hidden="true" />
+                    <component :is="IconXboxX" class="size-5 text-red-400" aria-hidden="true" />
                 </div>
                 <div class="ml-3">
                     <h3 class="text-sm font-medium text-red-800">{{ $t('Unfortunately there were {0} errors during transmission.', [errorCount])}}</h3>
@@ -28,6 +28,8 @@
 </template>
 
 <script setup>
+
+import {IconXboxX} from "@tabler/icons-vue";
 
 const props = defineProps({
     errors: {

--- a/resources/js/Components/Calendar/Elements/Events/FullEventInCalendar.vue
+++ b/resources/js/Components/Calendar/Elements/Events/FullEventInCalendar.vue
@@ -7,7 +7,7 @@
              :class="event.considerOnMultiEdit ? 'block bg-green-200/50' : 'hidden bg-artwork-buttons-create/50'">
             <div v-if="event.considerOnMultiEdit" class="flex items-center h-full justify-center align-middle">
                 <div class="bg-white rounded-lg">
-                    <component is="IconSquareCheckFilled" class="size-6 text-green-500" />
+                    <component :is="IconSquareCheckFilled" class="size-6 text-green-500" />
                 </div>
             </div>
             <div class="justify-center items-center h-full gap-2 hidden">
@@ -260,7 +260,7 @@
             <Popover class="relative">
                 <Float auto-placement portal :offset="{  5 : -10}">
                     <PopoverButton class="flex items-center justify-start gap-1 ring-0 focus:ring-0">
-                        <component is="IconInfoCircle" class="size-6 " stroke-width="1.5"/>
+                        <component :is="IconInfoCircle" class="size-6 " stroke-width="1.5"/>
                         <div class="w-16 max-w-16 xsDark text-left" v-if="zoom_factor > 0.4">
                             <div v-if="usePage().props.auth.user.calendar_settings.event_name && event.eventName" class="truncate">
                                 {{ event.eventName }}
@@ -596,10 +596,10 @@ import {Link, router, usePage} from "@inertiajs/vue3";
 import {
     IconChecks,
     IconCirclePlus, IconCircleX, IconClock,
-    IconEdit,
+    IconEdit, IconInfoCircle,
     IconLock,
     IconLockOpen,
-    IconRepeat,
+    IconRepeat, IconSquareCheckFilled,
     IconTrash,
     IconUsersGroup,
     IconX

--- a/resources/js/Components/Calendar/Elements/PlanningSwitch.vue
+++ b/resources/js/Components/Calendar/Elements/PlanningSwitch.vue
@@ -5,7 +5,7 @@
                 <ToolTipComponent
                     direction="bottom"
                     :tooltip-text="$t('When active, newly created appointments are automatically planning appointments')"
-                    icon="IconCalendarCog"
+                    :icon="IconCalendarCog"
                     icon-size="h-4 w-4"
                 />
             </span>
@@ -13,7 +13,7 @@
                 <ToolTipComponent
                     direction="bottom"
                     :tooltip-text="$t('When active, newly created appointments are automatically planning appointments')"
-                    icon="IconCalendarCog"
+                    :icon="IconCalendarCog"
                     icon-size="h-4 w-4"
                 />
             </span>

--- a/resources/js/Components/Chat/AddNewChat.vue
+++ b/resources/js/Components/Chat/AddNewChat.vue
@@ -38,7 +38,7 @@
             <div class="rounded-md bg-yellow-50 p-4">
                 <div class="flex">
                     <div class="shrink-0">
-                        <component is="IconInfoSquareRoundedFilled" class="size-5 min-w-5 min-h-5 text-yellow-400" aria-hidden="true" />
+                        <component :is="IconInfoSquareRoundedFilled" class="size-5 min-w-5 min-h-5 text-yellow-400" aria-hidden="true" />
                     </div>
                     <div class="ml-3">
                         <p class="text-sm font-medium text-yellow-800">
@@ -79,6 +79,7 @@ import {XIcon} from "@heroicons/vue/outline";
 import Button from "@/Jetstream/Button.vue";
 import FormButton from "@/Layouts/Components/General/Buttons/FormButton.vue";
 import {ref} from "vue";
+import {IconInfoSquareRoundedFilled} from "@tabler/icons-vue";
 const props = defineProps({
 
 })

--- a/resources/js/Components/Chat/Components/SingleChatInOverview.vue
+++ b/resources/js/Components/Chat/Components/SingleChatInOverview.vue
@@ -9,7 +9,7 @@
             >
             <component
                 v-else
-                is="IconUsersGroup"
+                :is="IconUsersGroup"
                 class="size-10 rounded-full object-cover p-3 bg-blue-50 text-blue-900 border border-blue-100"
             />
         </div>
@@ -43,6 +43,7 @@
 import {computed, ref, watchEffect} from "vue";
 import {usePage} from "@inertiajs/vue3";
 import useCrypto from "@/Composeables/useCrypto.js";
+import {IconUsersGroup} from "@tabler/icons-vue";
 
 
 const props = defineProps({

--- a/resources/js/Components/Chat/PopupChat.vue
+++ b/resources/js/Components/Chat/PopupChat.vue
@@ -18,7 +18,7 @@
     <div :class="positionClass" :style="positionStyle" ref="chatRoot" data-chat-root>
         <div v-if="!isChatOpen">
             <div class="rounded-full shadow-lg bg-white p-2 cursor-pointer border border-gray-200 relative" @click="openChat">
-                <component is="IconBubbleText" class="size-10" />
+                <component :is="IconBubbleText" class="size-10" />
 
                 <span v-if="totalUnreadCount > 0" class="absolute inline-flex items-center w-6 h-6 -top-2 -right-2">
                     <!--<span class="absolute inline-flex h-full w-full animate-ping rounded-full bg-red-400 opacity-75"></span>-->
@@ -42,7 +42,7 @@
                                 <div v-if="!checkIfChatIsSelected" @click="openAddNewChat = true">
                                     <ToolTipComponent
                                         direction="top"
-                                        icon="IconPlus"
+                                        :icon="IconPlus"
                                         :tooltip-text="$t('Add new Chat')"
                                         class="cursor-pointer p-1 hover:bg-gray-100 rounded transition-colors duration-200"
                                         icon-class="size-5"
@@ -53,7 +53,7 @@
                                 <div @click="showPositionPicker = true">
                                     <ToolTipComponent
                                         direction="top"
-                                        icon="IconArrowsMove"
+                                        :icon="IconArrowsMove"
                                         :tooltip-text="$t('Change Chat position')"
                                         class="cursor-pointer p-1 hover:bg-gray-100 rounded transition-colors duration-200"
                                         icon-class="size-5"
@@ -61,7 +61,7 @@
                                 </div>
 
                                 <div class="" @click="closeChat">
-                                    <component is="IconX" class="size-5 cursor-pointer transition-colors duration-200 ease-in-out" aria-hidden="true" />
+                                    <component :is="IconX" class="size-5 cursor-pointer transition-colors duration-200 ease-in-out" aria-hidden="true" />
                                 </div>
                             </div>
                         </div>
@@ -71,7 +71,7 @@
                             <div v-if="!checkIfChatIsSelected" class="px-3 py-1">
                                 <div class="grid grid-cols-1">
                                     <input v-model="searchChat" type="text" name="account-number" id="account-number" class="col-start-1 border border-gray-200 row-start-1 block w-full rounded-md bg-white py-3 pr-10 pl-3 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-100 placeholder:text-gray-400 focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:pr-9 sm:text-sm/6" :placeholder="$t('Search in chats')" />
-                                    <component is="IconSearch" class="pointer-events-none col-start-1 row-start-1 mr-3 size-5 self-center justify-self-end text-gray-400 sm:size-4" aria-hidden="true" />
+                                    <component :is="IconSearch" class="pointer-events-none col-start-1 row-start-1 mr-3 size-5 self-center justify-self-end text-gray-400 sm:size-4" aria-hidden="true" />
                                 </div>
                             </div>
                             <div v-else class="bg-white px-4">
@@ -80,7 +80,7 @@
                                         <div class="mr-1 cursor-pointer" @click="goBackToChatList">
                                             <ToolTipComponent
                                                 direction="top"
-                                                icon="IconChevronLeft"
+                                                :icon="IconChevronLeft"
                                                 :tooltip-text="$t('Back to Chat List')"
                                             />
                                         </div>
@@ -100,12 +100,12 @@
                                             <div class="mr-1 cursor-pointer" @click="goBackToChatList">
                                                 <ToolTipComponent
                                                     direction="top"
-                                                    icon="IconChevronLeft"
+                                                    :icon="IconChevronLeft"
                                                     :tooltip-text="$t('Back to Chat List')"
                                                     use-translation
                                                 />
                                             </div>
-                                            <component is="IconUsersGroup" class="size-10 rounded-full object-cover p-3 bg-blue-50 text-blue-500 border border-blue-100" />
+                                            <component :is="IconUsersGroup" class="size-10 rounded-full object-cover p-3 bg-blue-50 text-blue-500 border border-blue-100" />
                                             <div class="ml-3">
                                                 <p class="text-sm text-gray-900">{{ chatPartner.name }}</p>
                                                 <p class="text-[9px] text-gray-500">{{ chatPartner.users.map((user) => user.full_name).join(', ') }}</p>
@@ -116,7 +116,7 @@
                                             <div @click="showRenameModal = true">
                                                 <ToolTipComponent
                                                     direction="top"
-                                                    icon="IconEdit"
+                                                    :icon="IconEdit"
                                                     :tooltip-text="$t('Rename Group Chat')"
                                                     class="cursor-pointer p-1 hover:bg-gray-100 rounded transition-colors duration-200 chat-tooltip-black-icon"
                                                     icon-size="size-4"
@@ -126,7 +126,7 @@
                                             <div @click="showDeleteConfirm = true">
                                                 <ToolTipComponent
                                                     direction="top"
-                                                    icon="IconTrash"
+                                                    :icon="IconTrash"
                                                     :tooltip-text="$t('Delete Group Chat')"
                                                     class="cursor-pointer p-1 hover:bg-gray-100 rounded transition-colors duration-200 chat-tooltip-black-icon"
                                                     icon-size="size-4"
@@ -140,7 +140,7 @@
                         <div v-if="isLoading">
                             <div class="flex items-center justify-center max-h-96 min-h-96 w-full h-full">
                                 <!-- loading -->
-                                <component is="IconLoaderQuarter" class="motion-safe:animate-spin" />
+                                <component :is="IconLoaderQuarter" class="motion-safe:animate-spin" />
                             </div>
                         </div>
                         <div v-else class="px-3">
@@ -167,7 +167,7 @@
                                         <div class="rounded-md bg-red-50 p-4 mb-5">
                                             <div class="flex items-center">
                                                 <div class="shrink-0">
-                                                    <component is="IconInfoSquareRoundedFilled" class="size-6 text-red-400" aria-hidden="true" />
+                                                    <component :is="IconInfoSquareRoundedFilled" class="size-6 text-red-400" aria-hidden="true" />
                                                 </div>
                                                 <div class="ml-3">
                                                     <p class="text-xs font-lexend font-medium text-red-800">
@@ -225,7 +225,7 @@
                                 @keyup.enter.exact="scrollToBottom"
                             />
                             <div @click="sendMessage" class="rounded-full p-2 bg-artwork-buttons-create cursor-pointer hover:bg-artwork-buttons-hover duration-200 ease-in-out transition-colors">
-                                <component is="IconBrandTelegram" class="size-4 cursor-pointer text-white" aria-hidden="true" />
+                                <component :is="IconBrandTelegram" class="size-4 cursor-pointer text-white" aria-hidden="true" />
                             </div>
                         </div>
                     </div>
@@ -297,7 +297,7 @@
             />
             <!-- Schließen -->
             <div class="absolute top-2 right-2">
-                <component is="IconSquareRoundedX" class="size-6 text-white cursor-pointer" @click="showPositionPicker = false" />
+                <component :is="IconSquareRoundedX" class="size-6 text-white cursor-pointer" @click="showPositionPicker = false" />
             </div>
         </div>
     </div>
@@ -335,6 +335,16 @@ import {useUserStatus} from "@/Composeables/useUserStatus.js";
 import ToolTipComponent from "@/Components/ToolTips/ToolTipComponent.vue";
 import RenameGroupChatModal from "@/Components/Chat/Modals/RenameGroupChatModal.vue";
 import DeleteGroupChatModal from "@/Components/Chat/Modals/DeleteGroupChatModal.vue";
+import {
+    IconArrowsMove, IconBrandTelegram, IconBubbleText,
+    IconChevronLeft,
+    IconEdit, IconInfoSquareRoundedFilled,
+    IconLoaderQuarter,
+    IconPlus,
+    IconSearch, IconSquareRoundedX,
+    IconTrash, IconUsersGroup,
+    IconX
+} from "@tabler/icons-vue";
 const { getUserStatus } = useUserStatus()
 
 const props = defineProps({})

--- a/resources/js/Components/Checklist/ChecklistFunctionBar.vue
+++ b/resources/js/Components/Checklist/ChecklistFunctionBar.vue
@@ -27,7 +27,7 @@
 
             </slot>
             <div class="flex items-center w-max" v-if="canEditComponent && (isAdmin || projectCanWriteIds?.includes($page.props.auth.user.id) || projectManagerIds.includes($page.props.auth.user.id)) || can('can use checklists') && isInOwnTaskManagement">
-                <GlassyIconButton text="New checklist" icon="IconPlus" @click="openAddChecklistModal = true" />
+                <GlassyIconButton text="New checklist" :icon="IconPlus" @click="openAddChecklistModal = true" />
             </div>
         </div>
     </div>
@@ -47,7 +47,7 @@
 <script setup>
 
 import AddButtonSmall from "@/Layouts/Components/General/Buttons/AddButtonSmall.vue";
-import {IconLayoutKanban, IconLayoutList} from "@tabler/icons-vue";
+import {IconLayoutKanban, IconLayoutList, IconPlus} from "@tabler/icons-vue";
 import {router, usePage} from "@inertiajs/vue3";
 import {ref} from "vue";
 import AddEditChecklistModal from "@/Components/Checklist/Modals/AddEditChecklistModal.vue";

--- a/resources/js/Components/Checklist/Components/SingleChecklistListView.vue
+++ b/resources/js/Components/Checklist/Components/SingleChecklistListView.vue
@@ -10,7 +10,7 @@
                         {{ checklist?.name }}
                     </div>
                     <div>
-                        <component is="IconChevronDown" class="h-6 w-6" :class="$page.props.auth.user.opened_checklists.includes(checklist?.id) ? 'rotate-180' : 'closed'" />
+                        <component :is="IconChevronDown" class="h-6 w-6" :class="$page.props.auth.user.opened_checklists.includes(checklist?.id) ? 'rotate-180' : 'closed'" />
                     </div>
                 </div>
 

--- a/resources/js/Components/FunctionBars/InventoryFunctionBar.vue
+++ b/resources/js/Components/FunctionBars/InventoryFunctionBar.vue
@@ -27,7 +27,7 @@
                                     <ToolTipComponent
                                         direction="right"
                                         :tooltip-text="$t('Jump around') + ' ' + $t('Day')"
-                                        icon="IconCalendar"
+                                        :icon="IconCalendar"
                                         icon-size="h-5 w-5 text-white" />
                                 </div>
                             </MenuItem>
@@ -36,7 +36,7 @@
                                     <ToolTipComponent
                                         direction="right"
                                         :tooltip-text="$t('Jump around') + ' ' + $t('Calendar week')"
-                                        icon="IconCalendarWeek"
+                                        :icon="IconCalendarWeek"
                                         icon-size="h-5 w-5 text-white" />
                                 </div>
                             </MenuItem>
@@ -45,7 +45,7 @@
                                     <ToolTipComponent
                                         direction="right"
                                         :tooltip-text="$t('Jump around') + ' ' + $t('Month')"
-                                        icon="IconCalendarMonth"
+                                        :icon="IconCalendarMonth"
                                         icon-size="h-5 w-5 text-white" />
                                 </div>
                             </MenuItem>

--- a/resources/js/Components/Globale/ComponentIcons.vue
+++ b/resources/js/Components/Globale/ComponentIcons.vue
@@ -1,8 +1,15 @@
 <script>
 import IconLib from "@/Mixins/IconLib.vue";
+import {
+    IconCornerDownRightDouble,
+    IconDeviceProjector,
+    IconHomeStar,
+    IconLayoutNavbarCollapse, IconLink
+} from "@tabler/icons-vue";
 
 export default {
     name: "ComponentIcons",
+    methods: {IconLink, IconLayoutNavbarCollapse, IconDeviceProjector, IconCornerDownRightDouble, IconHomeStar},
     mixins: [IconLib],
     props: ['type'],
 }
@@ -37,11 +44,11 @@ export default {
     <IconSeparator class="w-6 h-6" v-if="type === 'SeparatorComponent'" />
     <IconCurrencyEuro class="w-6 h-6" v-if="type === 'BudgetInformations'" />
     <IconApps class="w-6 h-6" v-if="type === 'BulkBody'" />
-    <component is="IconHomeStar" class="w-6 h-6" v-if="type === 'ArtistResidenciesComponent'" />
-    <component is="IconCornerDownRightDouble" class="w-6 h-6" v-if="type === 'GroupProjectDisplayComponent'" />
-    <component is="IconDeviceProjector" class="w-6 h-6" v-if="type === 'ProjectGroupDisplayComponent'" />
-    <component is="IconLayoutNavbarCollapse" class="w-6 h-6" v-if="type === 'DisclosureComponent'" />
-    <component is="IconLink" class="w-6 h-6" v-if="type === 'Link'" />
+    <component :is="IconHomeStar" class="w-6 h-6" v-if="type === 'ArtistResidenciesComponent'" />
+    <component :is="IconCornerDownRightDouble" class="w-6 h-6" v-if="type === 'GroupProjectDisplayComponent'" />
+    <component :is="IconDeviceProjector" class="w-6 h-6" v-if="type === 'ProjectGroupDisplayComponent'" />
+    <component :is="IconLayoutNavbarCollapse" class="w-6 h-6" v-if="type === 'DisclosureComponent'" />
+    <component :is="IconLink" class="w-6 h-6" v-if="type === 'Link'" />
 
     <!-- TextField, Checkbox, TextArea, Title, DropDown -->
 </template>

--- a/resources/js/Components/Inputs/TextInputComponent.vue
+++ b/resources/js/Components/Inputs/TextInputComponent.vue
@@ -14,7 +14,7 @@
         />
         <div v-if="this.modelValue?.length > 0" class="absolute right-1 top-0 bottom-0 flex items-center pr-2">
             <button @click="this.$emit('update:modelValue', '')" class="text-gray-500 hover:text-artwork-buttons-create">
-                <component is="IconX" class="size-4" />
+                <component :is="IconX" class="size-4" />
             </button>
         </div>
         <PlaceholderLabel :for="this.id" :label="this.label" v-if="showLabel" :is-small="isSmall"/>
@@ -25,8 +25,10 @@
 import {defineComponent} from "vue";
 import PlaceholderInputLabelContainer from "@/Components/Inputs/Container/PlaceholderInputLabelContainer.vue";
 import PlaceholderLabel from "@/Components/Inputs/Labels/PlaceholderLabel.vue";
+import {IconX} from "@tabler/icons-vue";
 
 export default defineComponent({
+    methods: {IconX},
     components: {PlaceholderLabel, PlaceholderInputLabelContainer},
     props: {
         id: {

--- a/resources/js/Components/ToolTips/HolidayToolTip.vue
+++ b/resources/js/Components/ToolTips/HolidayToolTip.vue
@@ -3,7 +3,7 @@
         <Float auto-placement portal :offset="{ mainAxis: 5, crossAxis: 35}">
             <div class="font-semibold text-artwork-buttons-context flex items-center justify-end" ref="menuButtonRef">
                 <MenuButton>
-                    <component is="IconBeach" class="flex-shrink-0 h-4 w-4" aria-hidden="true" />
+                    <component :is="IconBeach" class="flex-shrink-0 h-4 w-4" aria-hidden="true" />
                 </MenuButton>
             </div>
 
@@ -27,6 +27,7 @@
 
 import {Float} from "@headlessui-float/vue";
 import {MenuItems, MenuButton, Menu} from "@headlessui/vue";
+import {IconBeach} from "@tabler/icons-vue";
 
 const props = defineProps({
     placement: {

--- a/resources/js/Layouts/AppLayout.vue
+++ b/resources/js/Layouts/AppLayout.vue
@@ -18,7 +18,7 @@
                     <div class="ml-4 xsDark">{{ pushNotification.message }}</div>
                 </div>
                 <button type="button" class="-mt-4 mr-2">
-                    <component is="IconX" class="-mt-4 h-5 w-5 text-secondary hover:text-error relative"
+                    <component :is="IconX" class="-mt-4 h-5 w-5 text-secondary hover:text-error relative"
                            @click="closePushNotification(pushNotification.id)"/>
                 </button>
             </div>

--- a/resources/js/Layouts/Components/BudgetComponent.vue
+++ b/resources/js/Layouts/Components/BudgetComponent.vue
@@ -91,7 +91,7 @@
                                         </div>
                                         <div class="text-xs text-white text-right flex items-center gap-x-1">
                                             <ToolTipComponent
-                                                icon="IconFlagUp"
+                                                :icon="IconFlagUp"
                                                 :tooltip-text="$t('This Column is relevant for project groups')"
                                                 icon-size="size-4"
                                                 white-icon
@@ -1011,6 +1011,7 @@ export default {
         },
     },
     methods: {
+        IconFlagUp,
         calculateRelevantBudgetDataSumFormProjectsInGroupWhereCommented(type) {
             const data = this.$page.props.loadedProjectInformation?.BudgetTab?.projectGroupRelevantBudgetData;
             if (!data || !Array.isArray(data[type])) return 0;

--- a/resources/js/Layouts/Components/ContractModuleUploadModal.vue
+++ b/resources/js/Layouts/Components/ContractModuleUploadModal.vue
@@ -45,7 +45,7 @@
                                 {{ file.name }}
                             </div>
                             <div>
-                                <component is="IconCircleX" class="size-5 text-error cursor-pointer hover:text-artwork-buttons-hover transition-colors duration-300 ease-in-out" @click="files.splice(files.indexOf(file), 1)"/>
+                                <component :is="IconCircleX" class="size-5 text-error cursor-pointer hover:text-artwork-buttons-hover transition-colors duration-300 ease-in-out" @click="files.splice(files.indexOf(file), 1)"/>
                             </div>
                         </div>
                     </div>
@@ -73,6 +73,7 @@ import TextareaComponent from "@/Components/Inputs/TextareaComponent.vue";
 import MultiAlertComponent from "@/Components/Alerts/MultiAlertComponent.vue";
 import {useForm} from "@inertiajs/vue3";
 import BaseTextarea from "@/Artwork/Inputs/BaseTextarea.vue";
+import {IconCircleX} from "@tabler/icons-vue";
 
 export default {
     name: "ContractModuleUploadModal",
@@ -105,6 +106,7 @@ export default {
         }
     },
     methods: {
+        IconCircleX,
         selectNewFiles() {
             this.$refs.module_files.click();
         },

--- a/resources/js/Layouts/Components/General/Buttons/PlusButton.vue
+++ b/resources/js/Layouts/Components/General/Buttons/PlusButton.vue
@@ -1,9 +1,11 @@
 <script>
 import IconLib from "@/Mixins/IconLib.vue";
 import ToolTipComponent from "@/Components/ToolTips/ToolTipComponent.vue";
+import {IconCirclePlus} from "@tabler/icons-vue";
 
 export default {
     name: "PlusButton",
+    methods: {IconCirclePlus},
     components: {ToolTipComponent},
     mixins: [IconLib],
     props: {
@@ -20,7 +22,7 @@ export default {
         <ToolTipComponent
             direction="left"
             :tooltip-text="buttonText"
-            icon="IconCirclePlus"
+            :icon="IconCirclePlus"
             icon-size="h-8 w-8 text-white"
             stroke="2.5"
         />

--- a/resources/js/Layouts/Components/ProjectCreateModal.vue
+++ b/resources/js/Layouts/Components/ProjectCreateModal.vue
@@ -550,7 +550,7 @@
                                 :text="t('Set up events')"
                                 class="mt-8 inline-flex items-center"
                                 classes="!w-fit gap-x-2 h-12 bg-artwork-buttons-create">
-                                <component is="IconCalendarMonth" class="w-5 h-5" />
+                                <component :is="IconCalendarMonth" class="w-5 h-5" />
                             </BaseButton>
                             <BaseButton
                                 type="submit"
@@ -559,7 +559,7 @@
                                 class="mt-8 inline-flex items-center "
                                 classes="!w-fit gap-x-2 h-12"
                             >
-                                <component is="IconCirclePlus" class="w-5 h-5" />
+                                <component :is="IconCirclePlus" class="w-5 h-5" />
                             </BaseButton>
                         </div>
 

--- a/resources/js/Layouts/Components/ProjectCreateModal.vue
+++ b/resources/js/Layouts/Components/ProjectCreateModal.vue
@@ -343,7 +343,7 @@
                                 :text="t('Set up events')"
                                 class="mt-8 inline-flex items-center"
                                 classes="!w-fit gap-x-2 h-12 bg-artwork-buttons-create">
-                                <component is="IconCalendarMonth" class="w-5 h-5" />
+                                <component :is="IconCalendarMonth" class="w-5 h-5" />
                             </BaseButton>
                             <BaseButton
                                 type="submit"
@@ -352,7 +352,7 @@
                                 class="mt-8 inline-flex items-center "
                                 classes="!w-fit gap-x-2 h-12"
                             >
-                                <component is="IconCirclePlus" class="w-5 h-5" />
+                                <component :is="IconCirclePlus" class="w-5 h-5" />
                             </BaseButton>
                         </div>
                     </div>
@@ -617,6 +617,7 @@ import { ref, reactive, computed, defineProps, defineEmits } from 'vue';
 import { usePage } from '@inertiajs/vue3';
 import { usePermission } from '@/Composeables/Permission.js';
 import { useTranslation } from '@/Composeables/Translation.js';
+import {IconCalendarMonth, IconCirclePlus} from "@tabler/icons-vue";
 
 // Define props
 const props = defineProps({

--- a/resources/js/Layouts/Components/ProjectSettingsItem.vue
+++ b/resources/js/Layouts/Components/ProjectSettingsItem.vue
@@ -16,7 +16,7 @@
 
             </div>
             <div class="">
-                <GlassyIconButton text="Save" icon="IconCheck" @click="add" :disabled="!input"/>
+                <GlassyIconButton text="Save" :icon="IconCheck" @click="add" :disabled="!input"/>
             </div>
 
         </div>
@@ -39,6 +39,7 @@ import EditableTagComponent from "@/Components/Tags/EditableTagComponent.vue";
 import TextInputComponent from "@/Components/Inputs/TextInputComponent.vue";
 import BaseInput from "@/Artwork/Inputs/BaseInput.vue";
 import GlassyIconButton from "@/Artwork/Buttons/GlassyIconButton.vue";
+import {IconCheck} from "@tabler/icons-vue";
 
 export default {
     name: "ProjectSettingsItem",
@@ -85,6 +86,7 @@ export default {
         }
     },
     methods: {
+        IconCheck,
         add() {
             this.$emit('add', this.input, this.hex_code)
             this.input = ''

--- a/resources/js/Layouts/Components/ProjectStateTagComponent.vue
+++ b/resources/js/Layouts/Components/ProjectStateTagComponent.vue
@@ -2,7 +2,7 @@
     <span class="rounded-full items-center font-medium border px-3 mt-2 text-sm mr-1 mb-1 h-8 inline-flex" :style="{backgroundColor: backgroundColorWithOpacity(item.color), color: TextColorWithDarken(item.color), borderColor: TextColorWithDarken(item.color)}">
         <span class="cursor-pointer flex items-center" @click="showEditModal = true">
             {{ item.name }}
-            <component is="IconCalendarCog" v-if="item.is_planning" class="ml-1 h-4 w-4" />
+            <component :is="IconCalendarCog" v-if="item.is_planning" class="ml-1 h-4 w-4" />
         </span>
 
         <button type="button" @click="showConfirmation = true">
@@ -31,6 +31,7 @@ import { XIcon } from "@heroicons/vue/outline";
 import ColorHelper from "@/Mixins/ColorHelper.vue";
 import ProjectStateModal from "@/Layouts/Components/ProjectStateModal.vue";
 import ConfirmationComponent from "@/Layouts/Components/ConfirmationComponent.vue";
+import {IconCalendarCog} from "@tabler/icons-vue";
 
 export default {
     name: "ProjectStateTagComponent",
@@ -54,6 +55,7 @@ export default {
         };
     },
     methods: {
+        IconCalendarCog,
         updateState(updatedState) {
             this.$emit('update', updatedState);
             this.showEditModal = false;

--- a/resources/js/Layouts/Components/RoomFileUploadModal.vue
+++ b/resources/js/Layouts/Components/RoomFileUploadModal.vue
@@ -34,7 +34,7 @@
                                 {{ file.name }}
                             </div>
                             <div>
-                                <component is="IconCircleX" class="size-5 text-error cursor-pointer hover:text-artwork-buttons-hover transition-colors duration-300 ease-in-out" @click="files.splice(files.indexOf(file), 1)"/>
+                                <component :is="IconCircleX" class="size-5 text-error cursor-pointer hover:text-artwork-buttons-hover transition-colors duration-300 ease-in-out" @click="files.splice(files.indexOf(file), 1)"/>
                             </div>
                         </div>
                     </div>
@@ -58,6 +58,7 @@ import FormButton from "@/Layouts/Components/General/Buttons/FormButton.vue";
 import BaseModal from "@/Components/Modals/BaseModal.vue";
 import ModalHeader from "@/Components/Modals/ModalHeader.vue";
 import MultiAlertComponent from "@/Components/Alerts/MultiAlertComponent.vue";
+import {IconCircleX} from "@tabler/icons-vue";
 
 const props = defineProps({
     show: Boolean,

--- a/resources/js/Layouts/Components/ShiftPlanComponents/SingleUserEventShift.vue
+++ b/resources/js/Layouts/Components/ShiftPlanComponents/SingleUserEventShift.vue
@@ -14,7 +14,7 @@
                 <IconLock stroke-width="1.5" class="h-5 w-5 text-white"/>
             </div>
             <button type="button" @click="showRequestWorkTimeChangeModal = true" v-if="userToEditId === usePage().props.auth.user.id && type === 'user'">
-                <Component is="IconClockEdit" class="h-5 w-5 hover:text-blue-500 transition-colors duration-300 ease-in-out cursor-pointer" stroke-width="1.5"/>
+                <Component :is="IconClockEdit" class="h-5 w-5 hover:text-blue-500 transition-colors duration-300 ease-in-out cursor-pointer" stroke-width="1.5"/>
             </button>
         </div>
         <div class="flex flex-col bg-backgroundGray rounded-b-lg px-1 pt-1">
@@ -83,7 +83,7 @@
     />
 </template>
 <script setup>
-import {IconCalendarMonth, IconLock} from "@tabler/icons-vue";
+import {IconCalendarMonth, IconClockEdit, IconLock} from "@tabler/icons-vue";
 import {router} from "@inertiajs/vue3";
 import ShiftNoteComponent from "@/Layouts/Components/ShiftNoteComponent.vue";
 import UserPopoverTooltip from "@/Layouts/Components/UserPopoverTooltip.vue";

--- a/resources/js/Layouts/Components/SubPositionComponent.vue
+++ b/resources/js/Layouts/Components/SubPositionComponent.vue
@@ -200,7 +200,7 @@
                                     <div v-else class="flex items-center gap-x-1" :class="cell.column.color !== 'whiteColumn' ? cell.column.color : ''">
                                         <component @click="openRelevantBudgetDataSumModalForCell(cell)"
                                                    v-if="calculateRelevantBudgetDataSumFormProjectsInGroup(cell) > 0"
-                                                   is="IconList"
+                                                   :is="IconList"
                                                    class="h-5 w-5 mr-1 cursor-pointer border-2 rounded-md bg-artwork-icons-default-background text-artwork-icons-default-color border-artwork-icons-default-color"/>
                                         {{ toCurrencyString(calculateRelevantBudgetDataSumFormProjectsInGroup(cell)) }}
                                     </div>
@@ -390,6 +390,7 @@ import SageDragCellElement from "@/Pages/Projects/Components/SageDragCellElement
 import CurrencyFloatToStringFormatter from "@/Mixins/CurrencyFloatToStringFormatter.vue";
 import BaseMenu from "@/Components/Menu/BaseMenu.vue";
 import RelevantBudgetDataSumModal from "@/Pages/Projects/Components/Budget/RelevantBudgetDataSumModal.vue";
+import {IconList} from "@tabler/icons-vue";
 
 export default {
     mixins: [Permissions, IconLib, CurrencyFloatToStringFormatter],
@@ -517,6 +518,7 @@ export default {
         localStorage.removeItem('closedSubPositions')
     },
     methods: {
+        IconList,
         usePage,
         openRelevantBudgetDataSumModalForCell(cell) {
             const data = this.$page.props.loadedProjectInformation?.BudgetTab?.projectGroupRelevantBudgetData;

--- a/resources/js/Layouts/Components/UserPopoverTooltip.vue
+++ b/resources/js/Layouts/Components/UserPopoverTooltip.vue
@@ -24,15 +24,15 @@
                                 </div>
 
                                 <div class="text-sm font-bold flex items-center gap-x-2" v-if="user.position" :class="isWhite ? 'text-gray-500' : 'text-gray-300'">
-                                    <component is="IconMapPin" class="h-4 w-4" v-if="user.position"/>
+                                    <component :is="IconMapPin" class="h-4 w-4" v-if="user.position"/>
                                     {{ user.position }}
                                 </div>
                                 <div class="text-sm font-bold flex items-center gap-x-2" :class="isWhite ? 'text-gray-500' : 'text-gray-300'" v-if="user.email && !user.email_private || $can('can view private user info') || hasAdminRole()">
-                                    <component is="IconMail" class="h-4 w-4" v-if="user.email"/>
+                                    <component :is="IconMail" class="h-4 w-4" v-if="user.email"/>
                                     {{ user.email }}
                                 </div>
                                 <div class="text-sm font-bold flex items-center gap-x-2" :class="isWhite ? 'text-gray-500' : 'text-gray-300'" v-if="user.phone_number && !user.phone_private || $can('can view private user info') || hasAdminRole()">
-                                    <component is="IconDeviceMobile" class="h-4 w-4" v-if="user.phone_number"/>
+                                    <component :is="IconDeviceMobile" class="h-4 w-4" v-if="user.phone_number"/>
                                     {{ user.phone_number }}
                                 </div>
                                 <div class="col-span-4 mt-2 break-all text-xs italic" :class="isWhite ? 'text-gray-500' : 'text-gray-300'" v-if="user.description">
@@ -61,6 +61,7 @@
 import {Popover, PopoverButton, PopoverPanel} from '@headlessui/vue'
 import IconLib from "@/Mixins/IconLib.vue";
 import Permissions from "@/Mixins/Permissions.vue";
+import {IconDeviceMobile, IconMail, IconMapPin} from "@tabler/icons-vue";
 
 export default {
     name: "UserPopoverTooltip",
@@ -110,6 +111,9 @@ export default {
         }
     },
     methods: {
+        IconDeviceMobile,
+        IconMail,
+        IconMapPin,
         calculatePopoverPosition(event) {
             const {top, left, height, width} = event.target.getBoundingClientRect();
 

--- a/resources/js/Pages/Accommodation/Components/SingleAccommodation.vue
+++ b/resources/js/Pages/Accommodation/Components/SingleAccommodation.vue
@@ -20,8 +20,8 @@
     </div>
     <div class="flex items-center">
         <BaseMenu has-no-offset white-menu-background>
-            <BaseMenuItem @click="showCreateOrUpdateModal = true" title="Edit" white-menu-background/>
-            <BaseMenuItem @click="showDeleteModal = true" title="Delete" icon="IconTrash" white-menu-background/>
+            <BaseMenuItem @click="showCreateOrUpdateModal = true" title="Edit" :icon="IconEdit" white-menu-background/>
+            <BaseMenuItem @click="showDeleteModal = true" title="Delete" :icon="IconTrash" white-menu-background/>
         </BaseMenu>
     </div>
 
@@ -49,6 +49,7 @@ import {Link, router} from "@inertiajs/vue3";
 import BaseMenu from "@/Components/Menu/BaseMenu.vue";
 import {defineAsyncComponent, ref} from "vue";
 import ArtworkBaseDeleteModal from "@/Artwork/Modals/ArtworkBaseDeleteModal.vue";
+import {IconEdit, IconTrash} from "@tabler/icons-vue";
 
 const props = defineProps({
     accommodation: {

--- a/resources/js/Pages/Accommodation/Components/UpdateOrCreateAccommodation.vue
+++ b/resources/js/Pages/Accommodation/Components/UpdateOrCreateAccommodation.vue
@@ -48,7 +48,7 @@
                                         <div class="flex items-center gap-2">
                                             {{ $t('Cost per night') }}
                                             <ToolTipComponent
-                                                icon="IconInfoCircle"
+                                                :icon="IconInfoCircle"
                                                 icon-size="h-4 w-4"
                                                 :tooltip-text="$t('Cost per night tooltip')"
                                                 direction="top"
@@ -102,7 +102,7 @@
                             @click="showAddRoomType = true"
                             class="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-artwork-buttons-create bg-artwork-buttons-create/10 hover:bg-artwork-buttons-create/20 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-artwork-buttons-create"
                         >
-                            <component is="IconPlus" class="h-4 w-4 mr-2" />
+                            <component :is="IconPlus" class="h-4 w-4 mr-2" />
                             {{ $t('Add room type') }}
                         </button>
                     </div>
@@ -170,7 +170,7 @@
 
                 <!-- Empty State -->
                 <div v-if="selectedRoomTypes.length === 0" class="mt-4 text-center py-8 border-2 border-dashed border-gray-300 rounded-lg">
-                    <component is="IconHome" class="mx-auto h-12 w-12 text-gray-400" />
+                    <component :is="IconHome" class="mx-auto h-12 w-12 text-gray-400" />
                     <h3 class="mt-2 text-sm font-medium text-gray-900">{{ $t('No room types') }}</h3>
                     <p class="mt-1 text-sm text-gray-500">{{ $t('Get started by adding a room type to this accommodation.') }}</p>
                     <div class="mt-6">
@@ -179,7 +179,7 @@
                             @click="showAddRoomType = true"
                             class="inline-flex items-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-artwork-buttons-create hover:bg-artwork-buttons-create/90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-artwork-buttons-create"
                         >
-                            <component is="IconPlus" class="h-4 w-4 mr-2" />
+                            <component :is="IconPlus" class="h-4 w-4 mr-2" />
                             {{ $t('Add room type') }}
                         </button>
                     </div>
@@ -215,6 +215,7 @@ import ArtworkBaseModalButton from "@/Artwork/Buttons/ArtworkBaseModalButton.vue
 import {ListboxButton, ListboxOption, ListboxOptions, Listbox} from "@headlessui/vue";
 import ArtworkBaseListbox from "@/Artwork/Listbox/ArtworkBaseListbox.vue";
 import ToolTipComponent from "@/Components/ToolTips/ToolTipComponent.vue";
+import {IconHome, IconInfoCircle, IconPlus} from "@tabler/icons-vue";
 
 const props = defineProps({
     accommodation: {

--- a/resources/js/Pages/Accommodation/Show.vue
+++ b/resources/js/Pages/Accommodation/Show.vue
@@ -4,7 +4,7 @@
             <div>
                 <div class="mb-4">
                     <Link :href="route('accommodation.index')" class="inline-flex items-center text-sm font-medium text-artwork-buttons-hover hover:text-artwork-buttons-hover/80">
-                        <component is="IconArrowLeft" class="h-4 w-4 mr-2" />
+                        <component :is="IconArrowLeft" class="h-4 w-4 mr-2" />
                         {{ $t('Back to accommodations overview') }}
                     </Link>
                 </div>
@@ -56,7 +56,7 @@
                                             <div class="flex items-center gap-2">
                                                 {{ $t('Cost per night') }}
                                                 <ToolTipComponent
-                                                    icon="IconInfoCircle"
+                                                    :icon="IconInfoCircle"
                                                     icon-size="h-4 w-4"
                                                     :tooltip-text="$t('Cost per night tooltip')"
                                                     direction="top"
@@ -110,7 +110,7 @@
                                 @click="showAddRoomType = true"
                                 class="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-artwork-buttons-create bg-artwork-buttons-create/10 hover:bg-artwork-buttons-create/20 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-artwork-buttons-create"
                             >
-                                <component is="IconPlus" class="h-4 w-4 mr-2" />
+                                <component :is="IconPlus" class="h-4 w-4 mr-2" />
                                 {{ $t('Add room type') }}
                             </button>
                         </div>
@@ -150,7 +150,7 @@
 
                     <!-- Empty State -->
                     <div v-if="selectedRoomTypes.length === 0" class="mt-4 text-center py-8 border-2 border-dashed border-gray-300 rounded-lg">
-                        <component is="IconHome" class="mx-auto h-12 w-12 text-gray-400" />
+                        <component :is="IconHome" class="mx-auto h-12 w-12 text-gray-400" />
                         <h3 class="mt-2 text-sm font-medium text-gray-900">{{ $t('No room types') }}</h3>
                         <p class="mt-1 text-sm text-gray-500">{{ $t('Get started by adding a room type to this accommodation.') }}</p>
                         <div class="mt-6">
@@ -159,7 +159,7 @@
                                 @click="showAddRoomType = true"
                                 class="inline-flex items-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-artwork-buttons-create hover:bg-artwork-buttons-create/90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-artwork-buttons-create"
                             >
-                                <component is="IconPlus" class="h-4 w-4 mr-2" />
+                                <component :is="IconPlus" class="h-4 w-4 mr-2" />
                                 {{ $t('Add room type') }}
                             </button>
                         </div>
@@ -220,6 +220,7 @@ import ArtworkSingleContact from "@/Artwork/Contact/ArtworkSingleContact.vue";
 import ArtworkBaseModalButton from "@/Artwork/Buttons/ArtworkBaseModalButton.vue";
 import ArtworkBaseListbox from "@/Artwork/Listbox/ArtworkBaseListbox.vue";
 import ToolTipComponent from "@/Components/ToolTips/ToolTipComponent.vue";
+import {IconArrowLeft, IconHome, IconInfoCircle, IconPlus} from "@tabler/icons-vue";
 
 const props = defineProps({
     accommodation: {

--- a/resources/js/Pages/Artist/Components/SingleArtistInTable.vue
+++ b/resources/js/Pages/Artist/Components/SingleArtistInTable.vue
@@ -5,14 +5,14 @@
     <td class="py-4 pr-4 pl-4 text-sm whitespace-nowrap text-gray-500 sm:pr-0 dark:text-gray-300 flex items-center gap-x-2">
         <button @click="showCreateOrUpdateArtistModal = true">
             <ToolTipComponent
-                icon="IconEdit"
+                :icon="IconEdit"
                 :tooltip-text="$t('Edit artist')"
                 direction="bottom"
             />
         </button>
         <button @click="showConfirmDeleteModal = true">
             <ToolTipComponent
-                icon="IconTrash"
+                :icon="IconTrash"
                 :tooltip-text="$t('Delete artist')"
                 direction="bottom"
             />
@@ -39,6 +39,7 @@ import {router} from "@inertiajs/vue3";
 import {defineAsyncComponent, ref} from "vue";
 import ToolTipComponent from "@/Components/ToolTips/ToolTipComponent.vue";
 import type { Artist } from "@/Pages/Artist/types/Artist";
+import {IconEdit, IconTrash} from "@tabler/icons-vue";
 
 const props = defineProps<{
     artist?: Artist;

--- a/resources/js/Pages/Artist/Index.vue
+++ b/resources/js/Pages/Artist/Index.vue
@@ -17,7 +17,7 @@
                     </div>
                     <div class="mt-4 sm:mt-0 sm:ml-16 sm:flex-none flex items-center gap-x-4">
                         <ToolTipComponent
-                            icon="IconFileExport"
+                            :icon="IconFileExport"
                             :tooltip-text="$t('Export artists')"
                             direction="bottom"
                             @click="exportArtist"
@@ -66,6 +66,7 @@ import UserHeader from "@/Pages/Users/UserHeader.vue";
 import ArtworkBaseModalButton from "@/Artwork/Buttons/ArtworkBaseModalButton.vue";
 import {defineAsyncComponent, ref} from "vue";
 import ToolTipComponent from "@/Components/ToolTips/ToolTipComponent.vue";
+import {IconFileExport} from "@tabler/icons-vue";
 
 const props = defineProps({
     artists: {

--- a/resources/js/Pages/EventVerification/Components/SingleEventVerificationRequest.vue
+++ b/resources/js/Pages/EventVerification/Components/SingleEventVerificationRequest.vue
@@ -19,17 +19,17 @@
                 <div class="flex items-center justify-between mt-3">
                     <div>
                         <BaseCardButton text="Open in Calendar" @click="openPlanningCalendarWithEventId">
-                            <component is="IconCalendar" class="size-4" aria-hidden="true" />
+                            <component :is="IconCalendar" class="size-4" aria-hidden="true" />
                         </BaseCardButton>
                     </div>
                     <div>
                         <BaseCardButton text="Approve" @click="approveRequest" v-if="eventVerification.status === 'pending'" class="!bg-green-600 hover:!bg-green-800 capitalize text-xs font-lexend">
-                            <component is="IconCheckbox" class="size-4" aria-hidden="true" />
+                            <component :is="IconCheckbox" class="size-4" aria-hidden="true" />
                         </BaseCardButton>
                     </div>
                     <div>
                         <BaseCardButton text="Reject" @click="showRejectEventVerificationRequestModal = true" v-if="eventVerification.status === 'pending'" class="!bg-red-500 hover:!bg-red-800 capitalize text-xs font-lexend">
-                            <component is="IconBan" class="size-4" aria-hidden="true" />
+                            <component :is="IconBan" class="size-4" aria-hidden="true" />
                         </BaseCardButton>
                     </div>
                 </div>
@@ -94,6 +94,7 @@ import {defineAsyncComponent, ref} from "vue";
 import WhiteInnerCard from "@/Artwork/Cards/WhiteInnerCard.vue";
 import BaseCardButton from "@/Artwork/Buttons/BaseCardButton.vue";
 import dayjs from "dayjs";
+import {IconBan, IconCalendar, IconCheckbox} from "@tabler/icons-vue";
 
 const props = defineProps({
     eventVerification: {

--- a/resources/js/Pages/Inventory/Components/Article/Modals/AddEditArticleModal.vue
+++ b/resources/js/Pages/Inventory/Components/Article/Modals/AddEditArticleModal.vue
@@ -560,7 +560,7 @@
                                                     :display-value="(person) => property.value ? rooms?.find((room) => room.id === parseInt(property.value) )?.name : ''"/>
                                                 <ComboboxButton
                                                     class="absolute inset-y-0 right-0 flex items-center rounded-r-md px-2 focus:outline-hidden">
-                                                    <component is="IconSelector" class="size-5 text-gray-400"
+                                                    <component :is="IconSelector" class="size-5 text-gray-400"
                                                                aria-hidden="true"/>
                                                 </ComboboxButton>
 
@@ -595,7 +595,7 @@
                                                     :display-value="(person) => property.value ? manufacturers?.find((manufacturer) => manufacturer.id === parseInt(property.value) )?.name : ''"/>
                                                 <ComboboxButton
                                                     class="absolute inset-y-0 right-0 flex items-center rounded-r-md px-2 focus:outline-hidden">
-                                                    <component is="IconSelector" class="size-5 text-gray-400"
+                                                    <component :is="IconSelector" class="size-5 text-gray-400"
                                                                aria-hidden="true"/>
                                                 </ComboboxButton>
 
@@ -632,7 +632,7 @@
                                                    class="sr-only"/>
                                             <div class="flex items-center gap-x-2">
                                                 <div class="flex items-center gap-x-2">
-                                                    <component is="IconPhoto" class="size-5 shrink-0 text-gray-400"
+                                                    <component :is="IconPhoto" class="size-5 shrink-0 text-gray-400"
                                                                aria-hidden="true"/>
                                                     <div class="flex">
                                                         <div class="truncate font-medium">{{

--- a/resources/js/Pages/Inventory/Components/Article/Modals/AddEditArticleModal.vue
+++ b/resources/js/Pages/Inventory/Components/Article/Modals/AddEditArticleModal.vue
@@ -380,7 +380,7 @@
                                                    class="sr-only"/>
                                             <div class="flex items-center gap-x-2">
                                                 <div class="flex items-center gap-x-2">
-                                                    <component is="IconPhoto" class="size-5 shrink-0 text-gray-400"
+                                                    <component :is="IconPhoto" class="size-5 shrink-0 text-gray-400"
                                                                aria-hidden="true"/>
                                                     <div class="flex">
                                                         <div class="truncate font-medium">{{
@@ -392,7 +392,7 @@
                                                 <button type="button"
                                                         class="text-gray-400 hover:text-red-600 hover:animate-pulse duration-200 ease-in-out"
                                                         @click="property.value = null">
-                                                    <component is="IconTrash" class="h-5 w-5" aria-hidden="true"/>
+                                                    <component :is="IconTrash" class="h-5 w-5" aria-hidden="true"/>
                                                 </button>
                                             </div>
                                         </div>
@@ -576,7 +576,7 @@
                                                                 </span>
                                                             <span v-if="selected"
                                                                   :class="['absolute inset-y-0 right-0 flex items-center pr-4', active ? 'text-white' : 'text-indigo-600']">
-                                                                  <component is="IconCheck" class="size-5"
+                                                                  <component :is="IconCheck" class="size-5"
                                                                              aria-hidden="true"/>
                                                                 </span>
                                                         </li>
@@ -611,7 +611,7 @@
                                                                 </span>
                                                             <span v-if="selected"
                                                                   :class="['absolute inset-y-0 right-0 flex items-center pr-4', active ? 'text-white' : 'text-indigo-600']">
-                                                                  <component is="IconCheck" class="size-5"
+                                                                  <component :is="IconCheck" class="size-5"
                                                                              aria-hidden="true"/>
                                                                 </span>
                                                         </li>
@@ -644,7 +644,7 @@
                                                 <button type="button"
                                                         class="text-gray-400 hover:text-red-600 hover:animate-pulse duration-200 ease-in-out"
                                                         @click="property.value = null">
-                                                    <component is="IconTrash" class="h-5 w-5" aria-hidden="true"/>
+                                                    <component :is="IconTrash" class="h-5 w-5" aria-hidden="true"/>
                                                 </button>
                                             </div>
                                         </div>
@@ -668,7 +668,7 @@
                                         <button type="button" v-if="articleForm.detailed_article_quantities.length > 1"
                                                 class="invisible group-hover:visible text-gray-400 hover:text-red-600 hover:animate-pulse duration-200 ease-in-out absolute right-2 top-1/2 transform -translate-y-1/2"
                                                 @click="removeDetailedArticle(index)">
-                                            <component is="IconTrash" class="h-5 w-5" aria-hidden="true"/>
+                                            <component :is="IconTrash" class="h-5 w-5" aria-hidden="true"/>
                                         </button>
                                     </td>
                                 </tr>
@@ -690,7 +690,7 @@
                                                         classes="text-artwork-buttons-create"
                                                         icon-right
                                                         stroke="2"
-                                                        icon="IconClick"
+                                                        :icon="IconClick"
                                                         icon-size="size-4"
                                                         :tooltip-text="$t('Click to set the article quantity to the detailed article quantity')"/>
                                                 </span>
@@ -719,7 +719,7 @@
                 <div class="pt-5">
                     <div @click="addNewDetailedArticle"
                          class="w-fit flex items-center gap-x-2 text-gray-400 font-lexend font-bold select-none cursor-pointer hover:text-gray-600 duration-200 ease-in-out">
-                        <component is="IconLibraryPlus" class="h-5 w-5" aria-hidden="true"/>
+                        <component :is="IconLibraryPlus" class="h-5 w-5" aria-hidden="true"/>
                         <span>
                             {{ $t('Add new detailed article') }}
                         </span>
@@ -758,7 +758,15 @@ import {XCircleIcon} from "@heroicons/vue/solid";
 import BaseInput from "@/Artwork/Inputs/BaseInput.vue";
 import BaseTextarea from "@/Artwork/Inputs/BaseTextarea.vue";
 import ArtworkBaseModal from "@/Artwork/Modals/ArtworkBaseModal.vue";
-import {IconCheck, IconChevronUp, IconClick, IconInfoCircle, IconPhotoPlus, IconSelector} from "@tabler/icons-vue";
+import {
+    IconCheck,
+    IconChevronUp,
+    IconClick,
+    IconInfoCircle,
+    IconLibraryPlus, IconPhoto,
+    IconPhotoPlus,
+    IconSelector, IconTrash
+} from "@tabler/icons-vue";
 
 const props = defineProps({
     article: {

--- a/resources/js/Pages/Inventory/InventoryManagement/InventoryCategory.vue
+++ b/resources/js/Pages/Inventory/InventoryManagement/InventoryCategory.vue
@@ -22,7 +22,7 @@
                 <ToolTipComponent
                     :tooltip-text="$t('Add new group')"
                     direction="bottom"
-                    icon="IconCirclePlus"
+                    :icon="IconCirclePlus"
                     icon-size="h-5 w-5"
                     stroke="1.5"
                     white-icon
@@ -91,7 +91,7 @@ import InventoryGroup from "@/Pages/Inventory/InventoryManagement/InventoryGroup
 import {
     IconCategory,
     IconChevronDown,
-    IconChevronUp,
+    IconChevronUp, IconCirclePlus,
     IconCopy,
     IconDotsVertical, IconEdit,
     IconTrash,

--- a/resources/js/Pages/Inventory/InventoryManagement/InventoryCraft.vue
+++ b/resources/js/Pages/Inventory/InventoryManagement/InventoryCraft.vue
@@ -12,7 +12,7 @@
                     <ToolTipComponent
                         :tooltip-text="$t('Craft settings')"
                         direction="bottom"
-                        icon="IconLink"
+                        :icon="IconLink"
                         icon-size="h-5 w-5"
                         stroke="1.5"
                         classes="text-black cursor-pointer hover:text-artwork-buttons-create duration-150 ease-in-out transition-colors"
@@ -20,7 +20,7 @@
                     <ToolTipComponent
                         :tooltip-text="$t('Add new category')"
                         direction="bottom"
-                        icon="IconCirclePlus"
+                        :icon="IconCirclePlus"
                         icon-size="h-5 w-5"
                         stroke="1.5"
                         classes="text-black cursor-pointer hover:text-artwork-buttons-create duration-150 ease-in-out transition-colors"

--- a/resources/js/Pages/Inventory/Scheduling.vue
+++ b/resources/js/Pages/Inventory/Scheduling.vue
@@ -103,7 +103,7 @@
                             <span :class="[multiEditMode ? 'translate-x-5' : 'translate-x-0', 'inline-block h-6 w-6 border border-gray-300 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out']">
                                 <span :class="[multiEditMode ? 'opacity-0 duration-100 ease-out' : 'opacity-100 duration-200 ease-in z-20', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']" aria-hidden="true">
                                     <ToolTipComponent
-                                        icon="IconPencil"
+                                        :icon="IconPencil"
                                         icon-size="h-4 w-4"
                                         :tooltip-text="$t('Edit')"
                                         direction="right"
@@ -111,7 +111,7 @@
                                 </span>
                                 <span :class="[multiEditMode ? 'opacity-100 duration-200 ease-in z-20' : 'opacity-0 duration-100 ease-out', 'absolute inset-0 flex h-full w-full items-center justify-center transition-opacity']" aria-hidden="true">
                                     <ToolTipComponent
-                                        icon="IconPencil"
+                                        :icon="IconPencil"
                                         icon-size="h-4 w-4"
                                         :tooltip-text="$t('Edit')"
                                         direction="right"
@@ -180,7 +180,7 @@
                             />
                             <ToolTipComponent
                                 v-if="!searchOpened"
-                                icon="IconSearch"
+                                :icon="IconSearch"
                                 icon-size="h-5 w-5"
                                 classes="text-white"
                                 :tooltip-text="$t('Search')"
@@ -217,7 +217,7 @@ import {Link, router} from "@inertiajs/vue3";
 import {
     IconChevronDown,
     IconChevronsDown,
-    IconChevronUp,
+    IconChevronUp, IconPencil, IconSearch,
     IconX
 } from "@tabler/icons-vue";
 import {Switch} from "@headlessui/vue";

--- a/resources/js/Pages/InventorySetting/Components/AddEditArticlePropertyModal.vue
+++ b/resources/js/Pages/InventorySetting/Components/AddEditArticlePropertyModal.vue
@@ -32,7 +32,7 @@
                             <div class="relative mt-2">
                                 <ListboxButton class="menu-button">
                                     <div class="col-start-1 row-start-1 xsDark truncate pr-6">{{ selectedType?.name ? $t(selectedType?.name) : '' }}</div>
-                                    <component is="IconChevronDown" class="col-start-1 row-start-1 size-5 self-center justify-self-end text-gray-500 sm:size-4" :class="open ? 'rotate-180' : '' " aria-hidden="true" />
+                                    <component :is="IconChevronDown" class="col-start-1 row-start-1 size-5 self-center justify-self-end text-gray-500 sm:size-4" :class="open ? 'rotate-180' : '' " aria-hidden="true" />
                                 </ListboxButton>
 
                                 <transition leave-active-class="transition ease-in duration-100" leave-from-class="opacity-100" leave-to-class="opacity-0">
@@ -42,7 +42,7 @@
                                                 <span :class="[selected ? 'font-semibold' : 'font-normal', 'block truncate']">{{ $t(type.name) }}</span>
 
                                                 <span v-if="selected" :class="[active ? 'text-white' : 'text-indigo-600', 'absolute inset-y-0 right-0 flex items-center pr-4']">
-                                                    <component is="IconCheck" class="size-5" aria-hidden="true" />
+                                                    <component :is="IconCheck" class="size-5" aria-hidden="true" />
                                                 </span>
                                             </li>
                                         </ListboxOption>
@@ -60,14 +60,14 @@
                                 :label="$t('Selection value {index}', {index: index + 1})"
                             />
                             <button type="button" @click="propertyForm.select_values.splice(index, 1)" class="text-red-500 hover:text-red-700">
-                                <component is="IconX" class="size-5" aria-hidden="true" />
+                                <component :is="IconX" class="size-5" aria-hidden="true" />
                             </button>
 
                         </div>
 
                         <div class="flex items-center justify-end">
                             <button type="button" @click="propertyForm.select_values.push('')" class="text-gray-500 text-xs hover:text-gray-700 flex items-center font-lexend">
-                                <component is="IconPlus" class="size-4" aria-hidden="true" />
+                                <component :is="IconPlus" class="size-4" aria-hidden="true" />
                                 {{ $t('Selection Add value') }}
                             </button>
                         </div>
@@ -138,6 +138,7 @@ import {computed, ref} from "vue";
 import FormButton from "@/Layouts/Components/General/Buttons/FormButton.vue";
 import BaseInput from "@/Artwork/Inputs/BaseInput.vue";
 import BaseTextarea from "@/Artwork/Inputs/BaseTextarea.vue";
+import {IconCheck, IconChevronDown, IconPlus, IconX} from "@tabler/icons-vue";
 
 const props = defineProps({
     property: {

--- a/resources/js/Pages/InventorySetting/Components/AddEditCategoryModal.vue
+++ b/resources/js/Pages/InventorySetting/Components/AddEditCategoryModal.vue
@@ -43,7 +43,7 @@
                                             <div class="flex items-center justify-between">
                                                 {{ property?.name }}
                                                 <button type="button" @click="removePropertyFromCategory(property)" class="text-red-600 hover:text-red-900">
-                                                    <component is="IconTrash" class="h-5 w-5" aria-hidden="true" />
+                                                    <component :is="IconTrash" class="h-5 w-5" aria-hidden="true" />
                                                 </button>
                                             </div>
                                         </td>
@@ -71,7 +71,7 @@
                                                         :display-value="(person) => property.defaultValue ? props.rooms?.find((room) => room.id === parseInt(property.defaultValue) )?.name : ''"/>
                                                     <ComboboxButton
                                                         class="absolute inset-y-0 right-0 flex items-center rounded-r-md px-2 focus:outline-hidden">
-                                                        <component is="IconSelector" class="size-5 text-gray-400"
+                                                        <component :is="IconSelector" class="size-5 text-gray-400"
                                                                    aria-hidden="true"/>
                                                     </ComboboxButton>
 
@@ -87,7 +87,7 @@
                                                                     </span>
                                                                 <span v-if="selected"
                                                                       :class="['absolute inset-y-0 right-0 flex items-center pr-4', active ? 'text-white' : 'text-indigo-600']">
-                                                                      <component is="IconCheck" class="size-5"
+                                                                      <component :is="IconCheck" class="size-5"
                                                                                  aria-hidden="true"/>
                                                                     </span>
                                                             </li>
@@ -106,7 +106,7 @@
                                                         :display-value="(person) => property.defaultValue ? props.manufacturers?.find((manufacturer) => manufacturer.id === parseInt(property.defaultValue) )?.name : ''"/>
                                                     <ComboboxButton
                                                         class="absolute inset-y-0 right-0 flex items-center rounded-r-md px-2 focus:outline-hidden">
-                                                        <component is="IconSelector" class="size-5 text-gray-400"
+                                                        <component :is="IconSelector" class="size-5 text-gray-400"
                                                                    aria-hidden="true"/>
                                                     </ComboboxButton>
 
@@ -122,7 +122,7 @@
                                                                     </span>
                                                                 <span v-if="selected"
                                                                       :class="['absolute inset-y-0 right-0 flex items-center pr-4', active ? 'text-white' : 'text-indigo-600']">
-                                                                      <component is="IconCheck" class="size-5"
+                                                                      <component :is="IconCheck" class="size-5"
                                                                                  aria-hidden="true"/>
                                                                     </span>
                                                             </li>
@@ -145,7 +145,7 @@
                                             <PropertiesMenu white-menu-background has-no-offset>
                                                 <template v-slot:button>
                                                     <div class="flex items-center gap-x-2 text-gray-400 font-lexend font-bold cursor-pointer hover:text-gray-600 duration-200 ease-in-out">
-                                                        <component is="IconLibraryPlus" class="h-5 w-5" aria-hidden="true" />
+                                                        <component :is="IconLibraryPlus" class="h-5 w-5" aria-hidden="true" />
                                                         <span>
                                                             {{ $t('Add property') }}
                                                         </span>
@@ -177,7 +177,7 @@
                             :description="$t('Add sub-categories to the category.')"
                         />
                         <div class="flex items-center gap-x-2 text-gray-400 text-sm font-lexend font-bold cursor-pointer hover:text-gray-600 duration-200 ease-in-out" @click="addEmptySubCategory">
-                            <component is="IconCategoryPlus" class="size-4" aria-hidden="true" />
+                            <component :is="IconCategoryPlus" class="size-4" aria-hidden="true" />
                             <span>
                                 {{ $t('Add sub-category') }}
                             </span>
@@ -193,10 +193,10 @@
                                         <span v-else>{{ $t('Sub-Category without name. Please add a name')}}</span>
 
                                         <div>
-                                            <component is="IconTrash" class="h-5 w-5 text-red-600 hover:text-red-900 cursor-pointer" @click="removeSubCategoryFromCategory(subCategory)" />
+                                            <component :is="IconTrash" class="h-5 w-5 text-red-600 hover:text-red-900 cursor-pointer" @click="removeSubCategoryFromCategory(subCategory)" />
                                         </div>
                                     </div>
-                                    <component is="IconChevronUp"
+                                    <component :is="IconChevronUp"
                                         :class="open ? 'rotate-180 transform' : ''"
                                         class="h-5 w-5 text-artwork-buttons-context"
                                     />
@@ -236,7 +236,7 @@
                                                                 <div class="flex items-center justify-between">
                                                                     {{ property?.name }}
                                                                     <button type="button" @click="removePropertyFromSubCategory(property, subCategory)" class="text-red-600 hover:text-red-900">
-                                                                        <component is="IconTrash" class="h-5 w-5" aria-hidden="true" />
+                                                                        <component :is="IconTrash" class="h-5 w-5" aria-hidden="true" />
                                                                     </button>
                                                                 </div>
                                                             </td>
@@ -264,7 +264,7 @@
                                                                             :display-value="(person) => property.defaultValue ? props.rooms?.find((room) => room.id === parseInt(property.defaultValue) )?.name : ''"/>
                                                                         <ComboboxButton
                                                                             class="absolute inset-y-0 right-0 flex items-center rounded-r-md px-2 focus:outline-hidden">
-                                                                            <component is="IconSelector" class="size-5 text-gray-400"
+                                                                            <component :is="IconSelector" class="size-5 text-gray-400"
                                                                                        aria-hidden="true"/>
                                                                         </ComboboxButton>
 
@@ -280,7 +280,7 @@
                                                                                         </span>
                                                                                     <span v-if="selected"
                                                                                           :class="['absolute inset-y-0 right-0 flex items-center pr-4', active ? 'text-white' : 'text-indigo-600']">
-                                                                                          <component is="IconCheck" class="size-5"
+                                                                                          <component :is="IconCheck" class="size-5"
                                                                                                      aria-hidden="true"/>
                                                                                         </span>
                                                                                 </li>
@@ -299,7 +299,7 @@
                                                                             :display-value="(person) => property.defaultValue ? props.manufacturers?.find((manufacturer) => manufacturer.id === parseInt(property.defaultValue) )?.name : ''"/>
                                                                         <ComboboxButton
                                                                             class="absolute inset-y-0 right-0 flex items-center rounded-r-md px-2 focus:outline-hidden">
-                                                                            <component is="IconSelector" class="size-5 text-gray-400"
+                                                                            <component :is="IconSelector" class="size-5 text-gray-400"
                                                                                        aria-hidden="true"/>
                                                                         </ComboboxButton>
 
@@ -315,7 +315,7 @@
                                                                                         </span>
                                                                                     <span v-if="selected"
                                                                                           :class="['absolute inset-y-0 right-0 flex items-center pr-4', active ? 'text-white' : 'text-indigo-600']">
-                                                                                          <component is="IconCheck" class="size-5"
+                                                                                          <component :is="IconCheck" class="size-5"
                                                                                                      aria-hidden="true"/>
                                                                                         </span>
                                                                                 </li>
@@ -338,7 +338,7 @@
                                                                 <PropertiesMenu white-menu-background has-no-offset>
                                                                     <template v-slot:button>
                                                                         <div class="flex items-center gap-x-2 text-gray-400 font-lexend font-bold cursor-pointer hover:text-gray-600 duration-200 ease-in-out">
-                                                                            <component is="IconLibraryPlus" class="h-5 w-5" aria-hidden="true" />
+                                                                            <component :is="IconLibraryPlus" class="h-5 w-5" aria-hidden="true" />
                                                                             <span>
                                                                                 {{ $t('Add property') }}
                                                                             </span>
@@ -388,7 +388,7 @@ import {computed, onMounted, ref} from "vue";
 import TinyPageHeadline from "@/Components/Headlines/TinyPageHeadline.vue";
 import {Disclosure, DisclosureButton, DisclosurePanel, Combobox, ComboboxButton, ComboboxInput, ComboboxOption, ComboboxOptions} from "@headlessui/vue";
 import BaseInput from "@/Artwork/Inputs/BaseInput.vue";
-import {IconCheck, IconSelector} from "@tabler/icons-vue";
+import {IconCategoryPlus, IconCheck, IconChevronUp, IconLibraryPlus, IconSelector, IconTrash} from "@tabler/icons-vue";
 
 const props = defineProps({
     category: {

--- a/resources/js/Pages/InventorySetting/Components/SingleCategoryInSettings.vue
+++ b/resources/js/Pages/InventorySetting/Components/SingleCategoryInSettings.vue
@@ -13,10 +13,10 @@
         <td class="py-4 pr-4 pl-4 text-sm whitespace-nowrap text-gray-500 sm:pr-0 actions-column">
             <div class="flex items-center gap-x-4">
                 <button type="button" class="text-artwork-buttons-create hover:text-artwork-buttons-hover">
-                    <component is="IconEdit" @click="showAddEditCategoryModal = true" class="h-5 w-5" aria-hidden="true" />
+                    <component :is="IconEdit" @click="showAddEditCategoryModal = true" class="h-5 w-5" aria-hidden="true" />
                 </button>
                 <button type="button" class="text-red-600 hover:text-red-900">
-                    <component is="IconTrash" class="h-5 w-5" aria-hidden="true" @click="showDeleteConfirmation = true" />
+                    <component :is="IconTrash" class="h-5 w-5" aria-hidden="true" @click="showDeleteConfirmation = true" />
                 </button>
             </div>
         </td>
@@ -46,6 +46,7 @@ import AddEditCategoryModal from "@/Pages/InventorySetting/Components/AddEditCat
 import {ref} from "vue";
 import ConfirmDeleteModal from "@/Layouts/Components/ConfirmDeleteModal.vue";
 import {router} from "@inertiajs/vue3";
+import {IconEdit, IconTrash} from "@tabler/icons-vue";
 
 const props = defineProps({
     category: {

--- a/resources/js/Pages/InventorySetting/Components/SinglePropertyInSettings.vue
+++ b/resources/js/Pages/InventorySetting/Components/SinglePropertyInSettings.vue
@@ -23,10 +23,10 @@
         <td class="py-5 pr-4 pl-4 text-sm whitespace-nowrap text-gray-500 sm:pr-0 actions-column">
             <div class="flex items-center gap-x-4">
                 <button type="button" class="text-artwork-buttons-create hover:text-artwork-buttons-hover">
-                    <component is="IconEdit" class="h-5 w-5" aria-hidden="true" @click="showAddEditPropertyModal = true" />
+                    <component :is="IconEdit" class="h-5 w-5" aria-hidden="true" @click="showAddEditPropertyModal = true" />
                 </button>
                 <button type="button" class="text-red-600 hover:text-red-900" v-if="property.is_deletable">
-                    <component is="IconTrash" class="h-5 w-5" aria-hidden="true" @click="showDeleteConfirmation = true" />
+                    <component :is="IconTrash" class="h-5 w-5" aria-hidden="true" @click="showDeleteConfirmation = true" />
                 </button>
             </div>
         </td>
@@ -53,6 +53,7 @@ import ConfirmDeleteModal from "@/Layouts/Components/ConfirmDeleteModal.vue";
 import {ref} from "vue";
 import {router} from "@inertiajs/vue3";
 import AddEditArticlePropertyModal from "@/Pages/InventorySetting/Components/AddEditArticlePropertyModal.vue";
+import {IconEdit, IconTrash} from "@tabler/icons-vue";
 
 const props = defineProps({
     property: {

--- a/resources/js/Pages/IssueOfMaterial/Components/ArticleSearchFilterModal.vue
+++ b/resources/js/Pages/IssueOfMaterial/Components/ArticleSearchFilterModal.vue
@@ -14,7 +14,7 @@
                     <div class="col-start-1 row-start-1 truncate pr-6">
                         {{ selectedCategory?.name ?? $t('Please select a Category') }}
                     </div>
-                    <component is="IconChevronUp"
+                    <component :is="IconChevronUp"
                                class="col-start-1 row-start-1 size-5 self-center justify-self-end text-gray-500 sm:size-4"
                                aria-hidden="true"/>
                 </ListboxButton>
@@ -33,7 +33,7 @@
 
                                 <span v-if="selected"
                                       :class="[active ? 'text-white' : 'text-indigo-600', 'absolute inset-y-0 right-0 flex items-center pr-4']">
-                                                <component is="IconCheck" class="size-5" aria-hidden="true"/>
+                                                <component :is="IconCheck" class="size-5" aria-hidden="true"/>
                                             </span>
                             </li>
                         </ListboxOption>
@@ -68,6 +68,7 @@ import ArtworkBaseModal from "@/Artwork/Modals/ArtworkBaseModal.vue";
 import {Listbox, ListboxButton, ListboxLabel, ListboxOption, ListboxOptions} from "@headlessui/vue";
 import {onMounted, ref} from "vue";
 import BaseInput from "@/Artwork/Inputs/BaseInput.vue";
+import {IconCheck, IconChevronUp} from "@tabler/icons-vue";
 
 const props = defineProps({})
 

--- a/resources/js/Pages/IssueOfMaterial/Components/CreateInternMaterialIssueModul.vue
+++ b/resources/js/Pages/IssueOfMaterial/Components/CreateInternMaterialIssueModul.vue
@@ -87,7 +87,7 @@
 
                     <div class="col-span-full">
                         <button @click="$refs.internMaterialIssueFiles.click()" type="button" class="relative block w-full rounded-lg border-2 border-dashed border-gray-300 p-12 text-center hover:border-gray-400 focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:outline-hidden">
-                            <component is="IconFile" class="mx-auto size-12 text-gray-400" stroke-width="1" />
+                            <component :is="IconFile" class="mx-auto size-12 text-gray-400" stroke-width="1" />
                             <span class="mt-2 block text-sm font-semibold text-gray-900">{{ $t('File storage') }}</span>
                             <input
                                 @change="upload"
@@ -114,7 +114,7 @@
                                             <div>
                                                 <div class="flex items-center justify-end">
                                                     <button type="button" class="text-xs text-red-500" @click="removeFile(file.id)">
-                                                        <component is="IconTrash" class="h-4 w-4" stroke-width="1.5"/>
+                                                        <component :is="IconTrash" class="h-4 w-4" stroke-width="1.5"/>
                                                     </button>
                                                 </div>
                                             </div>
@@ -135,7 +135,7 @@
                                             <div>
                                                 <div class="flex items-center justify-end">
                                                     <button type="button" class="text-xs text-red-500" @click="internMaterialIssue.files.splice(index, 1)">
-                                                        <component is="IconTrash" class="h-4 w-4" stroke-width="1.5"/>
+                                                        <component :is="IconTrash" class="h-4 w-4" stroke-width="1.5"/>
                                                     </button>
                                                 </div>
                                             </div>
@@ -274,7 +274,7 @@ import debounce from "lodash.debounce";
 import ArticleSearch from "@/Components/SearchBars/ArticleSearch.vue";
 import ToolTipComponent from "@/Components/ToolTips/ToolTipComponent.vue";
 import SelectMaterialSetModal from "@/Pages/IssueOfMaterial/Components/SelectMaterialSetModal.vue";
-import {IconListSearch, IconLoader, IconTrash} from "@tabler/icons-vue";
+import {IconFile, IconListSearch, IconLoader, IconParentheses, IconTrash} from "@tabler/icons-vue";
 
 const props = defineProps({
     issueOfMaterial: {

--- a/resources/js/Pages/IssueOfMaterial/Components/CreateInternMaterialIssueModul.vue
+++ b/resources/js/Pages/IssueOfMaterial/Components/CreateInternMaterialIssueModul.vue
@@ -152,10 +152,10 @@
                 <div class="flex items-center w-full gap-x-4">
                     <ArticleSearch @article-selected="addArticleToIssue" id="articleSearchInModal" class="w-full"/>
                     <button type="button" @click="showArticleFilterModal = true" class="p-3 bg-gray-100 rounded-lg hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">
-                        <ToolTipComponent icon="IconListSearch" :tooltip-text="$t('Search for articles')" icon-size="size-7" tooltip-width="w-fit whitespace-nowrap" position="top" />
+                        <ToolTipComponent :icon="IconListSearch" :tooltip-text="$t('Search for articles')" icon-size="size-7" tooltip-width="w-fit whitespace-nowrap" position="top" />
                     </button>
                     <button type="button" @click="showSelectMaterialSetModal = true" class="p-3 bg-gray-100 rounded-lg hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 ">
-                        <ToolTipComponent icon="IconParentheses" :tooltip-text="$t('Select material sets')" icon-size="size-7" tooltip-width="w-fit whitespace-nowrap" position="top" />
+                        <ToolTipComponent :icon="IconParentheses" :tooltip-text="$t('Select material sets')" icon-size="size-7" tooltip-width="w-fit whitespace-nowrap" position="top" />
                     </button>
                 </div>
                 <div class="mt-4">
@@ -172,7 +172,7 @@
                                     <p class="text-xs flex items-center gap-x-1">{{ $t('Available stock for issue period') }}:
                                         <span v-if="!article.availableStockRequestIsLoading">{{ article.availableStock?.available }}</span>
                                         <span v-else class="flex items-center gap-x-1">{{ $t('Is queried') }}
-                                            <component is="IconLoader" class="inline-block h-4 w-4 animate-spin text-gray-400" stroke-width="1.5"/>
+                                            <component :is="IconLoader" class="inline-block h-4 w-4 animate-spin text-gray-400" stroke-width="1.5"/>
                                         </span>
                                     </p>
                                     <p v-if="article.quantity > article.availableStock?.available">
@@ -186,7 +186,7 @@
                                 </div>
                                 <div class="flex items-center justify-end w-5">
                                     <button type="button" class="text-xs text-red-500" @click="removeArticle(index)">
-                                        <component is="IconTrash" class="h-4 w-4" stroke-width="1.5"/>
+                                        <component :is="IconTrash" class="h-4 w-4" stroke-width="1.5"/>
                                     </button>
                                 </div>
                             </div>
@@ -216,7 +216,7 @@
                                     </div>
                                     <div class="flex items-center justify-end">
                                         <button type="button" class="text-xs text-red-500" @click="removeSpecialArticle(index)">
-                                            <component is="IconTrash" class="h-4 w-4" stroke-width="1.5"/>
+                                            <component :is="IconTrash" class="h-4 w-4" stroke-width="1.5"/>
                                         </button>
                                     </div>
                                 </div>
@@ -274,6 +274,7 @@ import debounce from "lodash.debounce";
 import ArticleSearch from "@/Components/SearchBars/ArticleSearch.vue";
 import ToolTipComponent from "@/Components/ToolTips/ToolTipComponent.vue";
 import SelectMaterialSetModal from "@/Pages/IssueOfMaterial/Components/SelectMaterialSetModal.vue";
+import {IconListSearch, IconLoader, IconTrash} from "@tabler/icons-vue";
 
 const props = defineProps({
     issueOfMaterial: {

--- a/resources/js/Pages/IssueOfMaterial/Components/ExternMaterialIssueModul.vue
+++ b/resources/js/Pages/IssueOfMaterial/Components/ExternMaterialIssueModul.vue
@@ -103,10 +103,10 @@
                 <div class="flex items-center w-full gap-x-4">
                     <ArticleSearch @article-selected="addArticleToIssue" class="w-full"/>
                     <button type="button" @click="showArticleFilterModal = true" class="p-3 bg-gray-100 rounded-lg hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">
-                        <ToolTipComponent icon="IconListSearch" :tooltip-text="$t('Search for articles')" icon-size="size-7" tooltip-width="w-fit whitespace-nowrap" position="top" />
+                        <ToolTipComponent :icon="IconListSearch" :tooltip-text="$t('Search for articles')" icon-size="size-7" tooltip-width="w-fit whitespace-nowrap" position="top" />
                     </button>
                     <button type="button" @click="showSelectMaterialSetModal = true" class="p-3 bg-gray-100 rounded-lg hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 ">
-                        <ToolTipComponent icon="IconParentheses" :tooltip-text="$t('Select material sets')" icon-size="size-7" tooltip-width="w-fit whitespace-nowrap" position="top" />
+                        <ToolTipComponent :icon="IconParentheses" :tooltip-text="$t('Select material sets')" icon-size="size-7" tooltip-width="w-fit whitespace-nowrap" position="top" />
                     </button>
                 </div>
                 <div class="mt-4">
@@ -123,7 +123,7 @@
                                     <p class="text-xs flex items-center gap-x-1">{{ $t('Available stock for issue period') }}:
                                         <span v-if="!article.availableStockRequestIsLoading">{{ article.availableStock?.available }}</span>
                                         <span v-else class="flex items-center gap-x-1">{{ $t('Is queried') }}
-                                            <component is="IconLoader" class="inline-block h-4 w-4 animate-spin text-gray-400" stroke-width="1.5"/>
+                                            <component :is="IconLoader" class="inline-block h-4 w-4 animate-spin text-gray-400" stroke-width="1.5"/>
                                         </span>
                                     </p>
                                     <p v-if="article.quantity > article.availableStock?.available">
@@ -137,7 +137,7 @@
                                 </div>
                                 <div class="flex items-center justify-end w-5">
                                     <button type="button" class="text-xs text-red-500" @click="removeArticle(index)">
-                                        <component is="IconTrash" class="h-4 w-4" stroke-width="1.5"/>
+                                        <component :is="IconTrash" class="h-4 w-4" stroke-width="1.5"/>
                                     </button>
                                 </div>
                             </div>
@@ -167,7 +167,7 @@
                                     </div>
                                     <div class="flex items-center justify-end">
                                         <button type="button" class="text-xs text-red-500" @click="removeSpecialArticle(index)">
-                                            <component is="IconTrash" class="h-4 w-4" stroke-width="1.5"/>
+                                            <component :is="IconTrash" class="h-4 w-4" stroke-width="1.5"/>
                                         </button>
                                     </div>
                                 </div>
@@ -224,6 +224,7 @@ import debounce from "lodash.debounce";
 import ArticleSearch from "@/Components/SearchBars/ArticleSearch.vue";
 import ToolTipComponent from "@/Components/ToolTips/ToolTipComponent.vue";
 import SelectMaterialSetModal from "@/Pages/IssueOfMaterial/Components/SelectMaterialSetModal.vue";
+import {IconListSearch, IconLoader, IconParentheses, IconTrash} from "@tabler/icons-vue";
 
 const props = defineProps({
     externMaterialIssue: {

--- a/resources/js/Pages/IssueOfMaterial/Components/ExternMaterialIssueModul.vue
+++ b/resources/js/Pages/IssueOfMaterial/Components/ExternMaterialIssueModul.vue
@@ -42,7 +42,7 @@
 
                     <div class="col-span-full">
                         <button @click="$refs.externMaterialIssueFiles.click()" type="button" class="relative block w-full rounded-lg border-2 border-dashed border-gray-300 p-12 text-center hover:border-gray-400 focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:outline-hidden">
-                            <component is="IconFile" class="mx-auto size-12 text-gray-400" stroke-width="1" />
+                            <component :is="IconFile" class="mx-auto size-12 text-gray-400" stroke-width="1" />
                             <span class="mt-2 block text-sm font-semibold text-gray-900">{{ $t('File storage') }}</span>
                             <input
                                 @change="upload"
@@ -66,7 +66,7 @@
                                             <div>
                                                 <div class="flex items-center justify-end">
                                                     <button type="button" class="text-xs text-red-500" @click="removeFile(file.id)">
-                                                        <component is="IconTrash" class="h-4 w-4" stroke-width="1.5"/>
+                                                        <component :is="IconTrash" class="h-4 w-4" stroke-width="1.5"/>
                                                     </button>
                                                 </div>
                                             </div>
@@ -87,7 +87,7 @@
                                             <div>
                                                 <div class="flex items-center justify-end">
                                                     <button type="button" class="text-xs text-red-500" @click="externMaterialIssueForm.files.splice(index, 1)">
-                                                        <component is="IconTrash" class="h-4 w-4" stroke-width="1.5"/>
+                                                        <component :is="IconTrash" class="h-4 w-4" stroke-width="1.5"/>
                                                     </button>
                                                 </div>
                                             </div>
@@ -224,7 +224,7 @@ import debounce from "lodash.debounce";
 import ArticleSearch from "@/Components/SearchBars/ArticleSearch.vue";
 import ToolTipComponent from "@/Components/ToolTips/ToolTipComponent.vue";
 import SelectMaterialSetModal from "@/Pages/IssueOfMaterial/Components/SelectMaterialSetModal.vue";
-import {IconListSearch, IconLoader, IconParentheses, IconTrash} from "@tabler/icons-vue";
+import {IconFile, IconListSearch, IconLoader, IconParentheses, IconTrash} from "@tabler/icons-vue";
 
 const props = defineProps({
     externMaterialIssue: {

--- a/resources/js/Pages/IssueOfMaterial/Components/SingleExternMaterialIssue.vue
+++ b/resources/js/Pages/IssueOfMaterial/Components/SingleExternMaterialIssue.vue
@@ -28,13 +28,13 @@
                 <div class="">
                     <div v-if="!externMaterialIssue?.special_items_done && externMaterialIssue?.special_items?.length > 0">
                         <span class="text-red-500 font-bold">
-                            <component is="IconAlertTriangle" class="size-4 inline-block mr-1" />
+                            <component :is="IconAlertTriangle" class="size-4 inline-block mr-1" />
                             {{ $t('Special items not completed') }}
                         </span>
                     </div>
                     <div v-else>
                         <span class="text-green-500 font-bold">
-                            <component is="IconCheck" class="size-4 inline-block mr-1" />
+                            <component :is="IconCheck" class="size-4 inline-block mr-1" />
                             {{ $t('Completed') }}
                         </span>
                     </div>
@@ -42,13 +42,13 @@
             </div>
             <div class="flex items-center justify-end w-full gap-x-3">
                 <div class="cursor-pointer">
-                    <component is="IconPrinter" class="size-5 mr-2" stroke-width="1.5" @click="printExternal()" />
+                    <component :is="IconPrinter" class="size-5 mr-2" stroke-width="1.5" @click="printExternal()" />
                 </div>
                 <BaseMenu white-menu-background has-no-offset menu-width="w-fit">
-                    <BaseMenuItem white-menu-background title="Edit" @click="showIssueOfMaterialModal = true" />
-                    <BaseMenuItem white-menu-background title="Enter return" icon="IconReceiptRefund" @click="showEnterExternalIssueReturnModal = true" v-if="!externMaterialIssue.received_by" />
-                    <BaseMenuItem white-menu-background title="Special items closed" icon="IconCheck" @click="setSpecialItemsDone" v-if="checkIfStatusOrHasAnySpecialItem" />
-                    <BaseMenuItem white-menu-background title="Delete" icon="IconTrash" @click="showIssueOfMaterialConfirmDeleteModal = true" />
+                    <BaseMenuItem white-menu-background title="Edit" :icon="IconEdit" @click="showIssueOfMaterialModal = true" />
+                    <BaseMenuItem white-menu-background title="Enter return" :icon="IconReceiptRefund" @click="showEnterExternalIssueReturnModal = true" v-if="!externMaterialIssue.received_by" />
+                    <BaseMenuItem white-menu-background title="Special items closed" :icon="IconCheck" @click="setSpecialItemsDone" v-if="checkIfStatusOrHasAnySpecialItem" />
+                    <BaseMenuItem white-menu-background title="Delete" :icon="IconTrash" @click="showIssueOfMaterialConfirmDeleteModal = true" />
                 </BaseMenu>
             </div>
         </div>
@@ -91,6 +91,7 @@ import ConfirmDeleteModal from "@/Layouts/Components/ConfirmDeleteModal.vue";
 import {router, usePage} from "@inertiajs/vue3";
 import EnterExternalIssueReturnModal from "@/Pages/IssueOfMaterial/Components/EnterExternalIssueReturnModal.vue";
 import ExternalMaterialIssueDetailModal from "@/Pages/IssueOfMaterial/Components/ExternalMaterialIssueDetailModal.vue";
+import {IconAlertTriangle, IconCheck, IconEdit, IconPrinter, IconReceiptRefund, IconTrash} from "@tabler/icons-vue";
 
 const props = defineProps({
     externMaterialIssue: {

--- a/resources/js/Pages/IssueOfMaterial/Components/SingleInternMaterialIssue.vue
+++ b/resources/js/Pages/IssueOfMaterial/Components/SingleInternMaterialIssue.vue
@@ -33,13 +33,13 @@
                 <div class="">
                     <div v-if="!issueOfMaterial?.special_items_done && issueOfMaterial?.special_items?.length > 0">
                         <span class="text-red-500 font-bold">
-                            <component is="IconAlertTriangle" class="size-4 inline-block mr-1" />
+                            <component :is="IconAlertTriangle" class="size-4 inline-block mr-1" />
                             {{ $t('Special items not completed') }}
                         </span>
                     </div>
                     <div v-else>
                         <span class="text-green-500 font-bold">
-                            <component is="IconCheck" class="size-4 inline-block mr-1" />
+                            <component :is="IconCheck" class="size-4 inline-block mr-1" />
                             {{ $t('Completed') }}
                         </span>
                     </div>
@@ -47,9 +47,9 @@
             </div>
             <div class="flex items-center justify-end w-full">
                 <BaseMenu white-menu-background has-no-offset menu-width="w-fit">
-                    <BaseMenuItem white-menu-background title="Edit" @click="showIssueOfMaterialModal = true" />
-                    <BaseMenuItem white-menu-background title="Special items closed" icon="IconCheck" @click="setSpecialItemsDone" v-if="checkIfStatusOrHasAnySpecialItem" />
-                    <BaseMenuItem white-menu-background title="Delete" icon="IconTrash" @click="showIssueOfMaterialConfirmDeleteModal = true" />
+                    <BaseMenuItem white-menu-background title="Edit" :icon="IconEdit" @click="showIssueOfMaterialModal = true" />
+                    <BaseMenuItem white-menu-background title="Special items closed" :icon="IconCheck" @click="setSpecialItemsDone" v-if="checkIfStatusOrHasAnySpecialItem" />
+                    <BaseMenuItem white-menu-background title="Delete" :icon="IconTrash" @click="showIssueOfMaterialConfirmDeleteModal = true" />
                 </BaseMenu>
             </div>
         </div>
@@ -83,6 +83,7 @@ import {computed, ref} from "vue";
 import ConfirmDeleteModal from "@/Layouts/Components/ConfirmDeleteModal.vue";
 import {router, usePage} from "@inertiajs/vue3";
 import DetailModalInternMaterialModal from "@/Pages/IssueOfMaterial/Components/DetailModalInternMaterialModal.vue";
+import {IconAlertTriangle, IconCheck, IconEdit, IconTrash} from "@tabler/icons-vue";
 
 const props = defineProps({
     issueOfMaterial: {

--- a/resources/js/Pages/IssueOfMaterial/ExternIssueOfMaterialManagement.vue
+++ b/resources/js/Pages/IssueOfMaterial/ExternIssueOfMaterialManagement.vue
@@ -6,13 +6,13 @@
                 <div class="flex items-center gap-x-1 w-96">
                     <ArticleSearch @article-selected="addArticleNameToFilter" class="w-72" />
                     <button type="button" @click="filterIssueByArticleIds" class="p-4 flex items-center justify-center bg-gray-100 shadow-sm border border-gray-200 rounded-lg hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">
-                        <component is="IconSearch" class="size-5" stroke-width="1.5"/>
+                        <component :is="IconSearch" class="size-5" stroke-width="1.5"/>
                     </button>
                 </div>
 
                 <div>
                     <BaseButton v-if="can('inventory.disposition') || is('artwork admin')" :text="$t('New issue of material')" @click="openIssueOfMaterialModal">
-                        <component is="IconCopyPlus" class="size-5 mr-2" />
+                        <component :is="IconCopyPlus" class="size-5 mr-2" />
                     </BaseButton>
                 </div>
             </div>
@@ -26,7 +26,7 @@
                     <div v-for="(articleName, index) in articleNamesForFilter" :key="index" class="bg-blue-50 text-blue-800 text-sm font-medium px-2.5 py-0.5 rounded-full flex items-center border border-blue-200 font-lexend">
                         {{ articleName.name }}
                         <button type="button" @click="articleNamesForFilter.splice(index, 1)" class="ml-2 text-gray-400 hover:text-gray-600 focus:outline-none">
-                            <component is="IconX" class="size-4" />
+                            <component :is="IconX" class="size-4" />
                         </button>
                     </div>
                 </div>
@@ -100,6 +100,7 @@ import ArticleSearch from "@/Components/SearchBars/ArticleSearch.vue";
 import {watch} from "vue";
 import {router} from "@inertiajs/vue3";
 import {can, is} from "laravel-permission-to-vuejs";
+import {IconCopyPlus, IconSearch, IconX} from "@tabler/icons-vue";
 
 const props = defineProps({
     issues: {

--- a/resources/js/Pages/IssueOfMaterial/IssueOfMaterialManagement.vue
+++ b/resources/js/Pages/IssueOfMaterial/IssueOfMaterialManagement.vue
@@ -9,13 +9,13 @@
                         class="w-72"
                     />
                     <button type="button" @click="filterIssueByArticleIds" class="p-4 flex items-center justify-center bg-gray-100 shadow-sm border border-gray-200 rounded-lg hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 cursor-pointer">
-                        <component is="IconSearch" class="size-5" stroke-width="1.5"/>
+                        <component :is="IconSearch" class="size-5" stroke-width="1.5"/>
                     </button>
                 </div>
 
                 <div>
                     <BaseButton v-if="can('inventory.disposition') || is('artwork admin')" :text="$t('New issue of material')" @click="openIssueOfMaterialModal">
-                        <component is="IconCopyPlus" class="size-5 mr-2" />
+                        <component :is="IconCopyPlus" class="size-5 mr-2" />
                     </BaseButton>
                 </div>
             </div>
@@ -29,7 +29,7 @@
                     <div v-for="(article, index) in articleNamesForFilter" :key="index" class="bg-blue-50 text-blue-800 text-sm font-medium px-2.5 py-0.5 rounded-full flex items-center border border-blue-200 font-lexend">
                         {{ article.name }}
                         <button type="button" @click="articleNamesForFilter.splice(index, 1)" class="ml-2 text-gray-400 hover:text-gray-600 focus:outline-none">
-                            <component is="IconX" class="size-4" />
+                            <component :is="IconX" class="size-4" />
                         </button>
                     </div>
                 </div>
@@ -106,6 +106,7 @@ import {router, usePage} from "@inertiajs/vue3";
 import {watch} from "vue";
 import BaseAlertComponent from "@/Components/Alerts/BaseAlertComponent.vue";
 import {can, is} from "laravel-permission-to-vuejs";
+import {IconCopyPlus, IconSearch, IconX} from "@tabler/icons-vue";
 
 const props = defineProps({
     issues: {

--- a/resources/js/Pages/Manufacturer/Components/General/SingleManufacturerInList.vue
+++ b/resources/js/Pages/Manufacturer/Components/General/SingleManufacturerInList.vue
@@ -35,8 +35,8 @@
             {{ $t('Manufacturer website') }}
         </a>
         <BaseMenu has-no-offset>
-            <BaseMenuItem @click="showAddEditManufacturerModal = true" icon="IconEdit" title="Edit Manufacturer" />
-            <BaseMenuItem icon="IconTrash" title="Delete Manufacturer" @click="showDeleteModal = true"/>
+            <BaseMenuItem @click="showAddEditManufacturerModal = true" :icon="IconEdit" title="Edit Manufacturer" />
+            <BaseMenuItem :icon="IconTrash" title="Delete Manufacturer" @click="showDeleteModal = true"/>
         </BaseMenu>
     </div>
 
@@ -64,6 +64,7 @@ import CreateOrUpdateManufacturerModal
 import {ref} from "vue";
 import ConfirmDeleteModal from "@/Layouts/Components/ConfirmDeleteModal.vue";
 import {router, Link} from "@inertiajs/vue3";
+import {IconEdit, IconTrash} from "@tabler/icons-vue";
 
 const props = defineProps({
     manufacturer: {

--- a/resources/js/Pages/MaterialSet/Components/CreateOrUpdateMaterialSetModal.vue
+++ b/resources/js/Pages/MaterialSet/Components/CreateOrUpdateMaterialSetModal.vue
@@ -46,7 +46,7 @@
                                 </td>
                                 <td class="py-4 pr-4 pl-4 text-sm whitespace-nowrap text-gray-500 sm:pr-0 flex items-center justify-center">
                                     <button type="button" @click="materialSetForm.items = materialSetForm.items.filter(i => i.id !== item.id)" class="text-red-600 hover:underline text-center">
-                                        <component is="IconTrash" class="size-4" />
+                                        <component :is="IconTrash" class="size-4" />
                                     </button>
                                 </td>
                             </tr>
@@ -72,6 +72,7 @@ import BaseInput from "@/Artwork/Inputs/BaseInput.vue";
 import ArticleSearch from "@/Components/SearchBars/ArticleSearch.vue";
 import BaseTextarea from "@/Artwork/Inputs/BaseTextarea.vue";
 import ArtworkBaseModalButton from "@/Artwork/Buttons/ArtworkBaseModalButton.vue";
+import {IconTrash} from "@tabler/icons-vue";
 
 const props = defineProps({
     materialSet: {

--- a/resources/js/Pages/MaterialSet/Components/SingleMaterialSet.vue
+++ b/resources/js/Pages/MaterialSet/Components/SingleMaterialSet.vue
@@ -12,10 +12,10 @@
         <td class="py-4 pr-4 pl-4 text-sm text-gray-500 sm:pr-0">
             <div class="flex space-x-3">
                 <button @click="showCreateOrUpdateMaterialSetModal = true" class="text-blue-600 hover:underline text-sm" v-if="can('set.create_edit') || is('artwork admin')">
-                    <component is="IconEdit" class="size-4 mr-1" />
+                    <component :is="IconEdit" class="size-4 mr-1" />
                 </button>
                 <button @click="showConfirmDeleteModal = true" class="text-red-600 hover:underline text-sm" v-if="can('set.delete') || is('artwork admin')">
-                    <component is="IconTrash" class="size-4 mr-1" />
+                    <component :is="IconTrash" class="size-4 mr-1" />
                 </button>
             </div>
         </td>
@@ -41,6 +41,7 @@
 import {computed, defineAsyncComponent, ref} from "vue";
 import {router} from "@inertiajs/vue3";
 import {can, is} from "laravel-permission-to-vuejs";
+import {IconEdit, IconTrash} from "@tabler/icons-vue";
 
 const props = defineProps({
     set: {

--- a/resources/js/Pages/MaterialSet/Index.vue
+++ b/resources/js/Pages/MaterialSet/Index.vue
@@ -3,7 +3,7 @@
         <div class="space-y-6 artwork-container">
             <div class="flex justify-between items-center">
                 <h1 class="text-xl font-semibold text-gray-800">{{ $t('Material Sets') }}</h1>
-                <GlassyIconButton icon="IconCopyPlus" v-if="can('set.create_edit') || is('artwork admin')" :text="$t('New Material Set')" @click="showCreateOrUpdateMaterialSetModal = true" />
+                <GlassyIconButton :icon="IconCopyPlus" v-if="can('set.create_edit') || is('artwork admin')" :text="$t('New Material Set')" @click="showCreateOrUpdateMaterialSetModal = true" />
             </div>
 
             <div class="mt-8 flow-root card white p-5">
@@ -55,6 +55,7 @@ import {ref} from "vue";
 import SingleMaterialSet from "@/Pages/MaterialSet/Components/SingleMaterialSet.vue";
 import {can, is} from "laravel-permission-to-vuejs";
 import GlassyIconButton from "@/Artwork/Buttons/GlassyIconButton.vue";
+import {IconCopyPlus} from "@tabler/icons-vue";
 
 const props = defineProps({
     materialSets: {

--- a/resources/js/Pages/MoneySources/MoneySourceManagement.vue
+++ b/resources/js/Pages/MoneySources/MoneySourceManagement.vue
@@ -203,7 +203,7 @@
                                 </Menu>
                                 <div class="flex ml-3"
                                      v-if="$can('view edit add money_sources') || $can('can edit and delete money sources') || $role('artwork admin')">
-                                    <GlassyIconButton text="New" icon="IconPlus" @click="openAddMoneySourceModal" />
+                                    <GlassyIconButton text="New" :icon="IconPlus" @click="openAddMoneySourceModal" />
                                 </div>
                             </div>
                         </div>
@@ -402,7 +402,7 @@ import {Link} from "@inertiajs/vue3";
 import Permissions from "@/Mixins/Permissions.vue";
 import ConfirmDeleteModal from "@/Layouts/Components/ConfirmDeleteModal.vue";
 import Input from "@/Layouts/Components/InputComponent.vue";
-import {IconPin} from '@tabler/icons-vue';
+import {IconPin, IconPlus} from '@tabler/icons-vue';
 import TagComponent from "@/Layouts/Components/TagComponent.vue";
 import Label from "@/Jetstream/Label.vue";
 import JetDialogModal from "@/Jetstream/DialogModal.vue";
@@ -522,6 +522,7 @@ export default defineComponent({
         },
     },
     methods: {
+        IconPlus,
         formatDateString(dateString) {
             let date = new Date(dateString),
                 day = date.getDate(),

--- a/resources/js/Pages/PlanningCalendar/Index.vue
+++ b/resources/js/Pages/PlanningCalendar/Index.vue
@@ -10,7 +10,7 @@
                     </p>
                     <button type="button" class="-m-1.5 flex-none p-1.5">
                         <span class="sr-only">Dismiss</span>
-                        <component is="IconX" class="size-5 text-white" aria-hidden="true" @click="showCalendarWarning = ''" />
+                        <component :is="IconX" class="size-5 text-white" aria-hidden="true" @click="showCalendarWarning = ''" />
                     </button>
                 </div>
             </div>
@@ -41,7 +41,7 @@ import AppLayout from "@/Layouts/AppLayout.vue";
 import {usePage} from "@inertiajs/vue3";
 import BaseCalendar from "@/Components/Calendar/BaseCalendar.vue";
 import {computed, onBeforeMount, onMounted, provide, ref} from "vue";
-import { IconAlertSquareRounded } from "@tabler/icons-vue";
+import {IconAlertSquareRounded, IconX} from "@tabler/icons-vue";
 
 const props = defineProps({
     period: {

--- a/resources/js/Pages/Projects/BuilderComponents/BuilderActionsComponent.vue
+++ b/resources/js/Pages/Projects/BuilderComponents/BuilderActionsComponent.vue
@@ -7,8 +7,8 @@
             title="Open"
             :icon="IconFolderOpen"
         />
-        <BaseMenuItem title="Edit" />
-        <BaseMenuItem title="Delete" icon="IconTrash" />
+        <BaseMenuItem title="Edit" :icon="IconEdit" />
+        <BaseMenuItem title="Delete" :icon="IconTrash" />
     </BaseMenu>
 </template>
 
@@ -17,7 +17,7 @@
 import BaseMenu from "@/Components/Menu/BaseMenu.vue";
 import BaseMenuItem from "@/Components/Menu/BaseMenuItem.vue";
 import {router} from "@inertiajs/vue3";
-import {IconCalendarMonth, IconFolderOpen} from "@tabler/icons-vue";
+import {IconCalendarMonth, IconEdit, IconFolderOpen, IconTrash} from "@tabler/icons-vue";
 
 const props = defineProps({
     project: {

--- a/resources/js/Pages/Projects/Components/ArtistResidenciesComponents/AddEditArtistResidenciesModal.vue
+++ b/resources/js/Pages/Projects/Components/ArtistResidenciesComponents/AddEditArtistResidenciesModal.vue
@@ -204,7 +204,7 @@
                                         <div class="flex items-center">
                                             <h4 class="xsLight">{{ $t('No. of overnight stays') }}</h4>
                                             <ToolTipComponent
-                                                icon="IconInfoCircle"
+                                                :icon="IconInfoCircle"
                                                 icon-size="h-4 w-4 ml-2"
                                                 :tooltip-text="$t('The number of nights is calculated from the arrival and departure dates.')"
                                                 direction="bottom"
@@ -224,7 +224,7 @@
                                         <div class="flex items-center">
                                             <h4 class="xsLight">{{ $t('Daily allowance entitlement') }}</h4>
                                             <ToolTipComponent
-                                                icon="IconInfoCircle"
+                                                :icon="IconInfoCircle"
                                                 icon-size="h-4 w-4 ml-2"
                                                 :tooltip-text="$t('Daily allowance entitlement is calculated from the number of overnight stays and the daily allowance.')"
                                                 direction="bottom"
@@ -356,7 +356,7 @@ import ArtworkBaseModal from "@/Artwork/Modals/ArtworkBaseModal.vue";
 import CountUp from "@/Artwork/Visual/CountUp.vue";
 import ArtworkBaseModalButton from "@/Artwork/Buttons/ArtworkBaseModalButton.vue";
 import ArtworkBaseListbox from "@/Artwork/Listbox/ArtworkBaseListbox.vue";
-import {IconCheck} from "@tabler/icons-vue";
+import {IconCheck, IconInfoCircle} from "@tabler/icons-vue";
 
 
 const props = defineProps({

--- a/resources/js/Pages/Projects/Components/BulkComponents/BulkBody.vue
+++ b/resources/js/Pages/Projects/Components/BulkComponents/BulkBody.vue
@@ -73,7 +73,7 @@
                 </div>
 
                 <ToolTipComponent
-                    icon="IconCircuitCapacitorPolarized"
+                    :icon="IconCircuitCapacitorPolarized"
                     icon-size="h-7 w-7"
                     :tooltip-text="$t('Customize column size')"
                     direction="bottom"
@@ -81,14 +81,14 @@
                     :class="!hasCreateEventsPermission ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'"
                 />
                 <ToolTipComponent
-                    icon="IconFileExport"
+                    :icon="IconFileExport"
                     icon-size="h-7 w-7"
                     :tooltip-text="$t('Export project list')"
                     direction="bottom"
                     @click="showExportModal = true"
                 />
                 <ToolTipComponent
-                    icon="IconCalendarMonth"
+                    :icon="IconCalendarMonth"
                     icon-size="h-7 w-7"
                     :tooltip-text="$t('Show project period in calendar')"
                     direction="bottom"
@@ -308,7 +308,13 @@
 <script setup>
 import BulkSingleEvent from "@/Pages/Projects/Components/BulkComponents/BulkSingleEvent.vue";
 import BaseButton from "@/Layouts/Components/General/Buttons/BaseButton.vue";
-import { IconCheck, IconCirclePlus } from "@tabler/icons-vue";
+import {
+    IconCalendarMonth,
+    IconCheck,
+    IconCirclePlus,
+    IconCircuitCapacitorPolarized,
+    IconFileExport
+} from "@tabler/icons-vue";
 import BulkHeader from "@/Pages/Projects/Components/BulkComponents/BulkHeader.vue";
 import {onMounted, ref, watch, provide, computed} from "vue";
 import {router, usePage} from "@inertiajs/vue3";

--- a/resources/js/Pages/Projects/Components/BulkComponents/BulkHeader.vue
+++ b/resources/js/Pages/Projects/Components/BulkComponents/BulkHeader.vue
@@ -80,7 +80,7 @@
                 {{ $t('Period') }}
               </span>
                             <ToolTipComponent
-                                icon="IconExclamationCircle"
+                                :icon="IconExclamationCircle"
                                 icon-size="h-5 w-5"
                                 direction="bottom"
                                 :tooltip-text="$t('If the start and end times are identical or the end time is before the start time, the end date is set to the next day; if no time is specified, the event is categorised as a full day.')"
@@ -103,6 +103,7 @@ import {ref, watch} from "vue";
 import ToolTipDefault from "@/Components/ToolTips/ToolTipDefault.vue";
 import {usePage} from "@inertiajs/vue3";
 import ToolTipComponent from "@/Components/ToolTips/ToolTipComponent.vue";
+import {IconExclamationCircle} from "@tabler/icons-vue";
 
 // Emit Event
 const emit = defineEmits(['update:modelValue']);

--- a/resources/js/Pages/Projects/Components/BulkComponents/BulkSingleEvent.vue
+++ b/resources/js/Pages/Projects/Components/BulkComponents/BulkSingleEvent.vue
@@ -189,7 +189,7 @@
             >
                 <div class="flex items-center gap-x-3">
                     <ToolTipComponent
-                        icon="IconNote"
+                        :icon="IconNote"
                         v-if="!isInModal"
                         :tooltip-text="$t('Edit the description')"
                         stroke="1.5"
@@ -206,7 +206,7 @@
 
                     <!-- Copy Menu -->
                     <BaseMenu show-custom-icon dots-color="!text-artwork-buttons-context" stroke-width="2"
-                              icon="IconCopy" translation-key="Copy" menu-width="w-fit" white-menu-background>
+                              :icon="IconCopy" translation-key="Copy" menu-width="w-fit" white-menu-background>
                         <div class="flex items-center gap-x-2 p-3">
                             <IconPlus class="w-6 h-6 min-w-6 min-h-6 text-artwork-buttons-context" stroke-width="2" />
                             <BaseInput
@@ -250,11 +250,11 @@
 
                     <!-- Edit/Delete Menu -->
                     <BaseMenu has-no-offset white-menu-background menu-width="!w-fit" v-if="!isInModal">
-                        <BaseMenuItem white-menu-background icon="IconEdit" title="Edit" @click="openEventComponent(event.id)" />
+                        <BaseMenuItem white-menu-background :icon="IconEdit" title="Edit" @click="openEventComponent(event.id)" />
                         <BaseMenuItem
                             v-if="(index > 0 && !event.copy) || !isInModal"
                             white-menu-background
-                            icon="IconTrash"
+                            :icon="IconTrash"
                             title="Put in the trash"
                             @click="openDeleteEventConfirmModal"
                         />
@@ -282,8 +282,8 @@
 import {
     IconCheck,
     IconChevronDown,
-    IconCircleCheckFilled,
-    IconPlus,
+    IconCircleCheckFilled, IconCopy, IconEdit, IconNote,
+    IconPlus, IconTrash,
 } from "@tabler/icons-vue";
 import {
     Listbox,

--- a/resources/js/Pages/Projects/Components/SelectUserForShiftMenu.vue
+++ b/resources/js/Pages/Projects/Components/SelectUserForShiftMenu.vue
@@ -93,7 +93,7 @@
 
                                             <div v-if="user.type === 0 && user.is_freelancer || user.type === 1">
                                                 <ToolTipComponent
-                                                    icon="IconId"
+                                                    :icon="IconId"
                                                     icon-size="w-4 h-4"
                                                     tooltip-text="Freelancer*in"
                                                     direction="left"
@@ -117,7 +117,7 @@
 
 import {Float} from "@headlessui-float/vue";
 import ToolTipComponent from "@/Components/ToolTips/ToolTipComponent.vue";
-import {IconChevronDown, IconChevronUp, IconFilter, IconSearch, IconX} from "@tabler/icons-vue";
+import {IconChevronDown, IconChevronUp, IconFilter, IconId, IconSearch, IconX} from "@tabler/icons-vue";
 import {MenuButton, MenuItems, Menu} from "@headlessui/vue";
 import Input from "@/Jetstream/Input.vue";
 import {computed, nextTick, ref, watch} from "vue"

--- a/resources/js/Pages/Projects/Components/ShiftBookedElementComponent.vue
+++ b/resources/js/Pages/Projects/Components/ShiftBookedElementComponent.vue
@@ -20,9 +20,9 @@
                     </span>
                     </div>
                 </div>
-                <component stroke-width="1.5"
+                <PropertyIcon stroke-width="1.5"
                     class=" block group-hover:hidden size-4"
-                    :is="getShiftQualificationById(user.pivot.shift_qualification_id).icon"/>
+                    :name="getShiftQualificationById(user.pivot.shift_qualification_id).icon"/>
             </div>
         </div>
         <template #xButton>
@@ -81,6 +81,7 @@ import SelectUserForShiftMenu from "@/Pages/Projects/Components/SelectUserForShi
 const { can, canAny, hasAdminRole } = usePermission(usePage().props)
 
 import {useTranslation} from "@/Composeables/Translation.js";
+import PropertyIcon from "@/Artwork/Icon/PropertyIcon.vue";
 const $t = useTranslation()
 
 const props = defineProps({

--- a/resources/js/Pages/Projects/Components/ShiftsQualificationsDropElement.vue
+++ b/resources/js/Pages/Projects/Components/ShiftsQualificationsDropElement.vue
@@ -6,7 +6,7 @@
                     <span class="h-4 w-4 rounded-full block bg-gray-500"></span>
                     <span class="text-xs">{{ $t('Unoccupied') }}</span>
                 </div>
-                <component stroke-width="1.5" class="size-4" :is="this.shiftQualification.icon"/>
+                <PropertyIcon stroke-width="1.5" class="size-4" :name="this.shiftQualification.icon"/>
             </div>
         </SelectUserForShiftMenu>
     </div>
@@ -40,11 +40,13 @@ import DragElement from "@/Pages/Projects/Components/DragElement.vue";
 import ColorHelper from "@/Mixins/ColorHelper.vue";
 import CraftFilter from "@/Components/Filter/CraftFilter.vue";
 import Input from "@/Jetstream/Input.vue";
+import PropertyIcon from "@/Artwork/Icon/PropertyIcon.vue";
 
 export default defineComponent({
     name: 'ShiftsQualificationsDropElement',
     mixins: [ColorHelper],
     components: {
+        PropertyIcon,
         IconFilter, Input, IconSearch, IconChevronUp, CraftFilter, IconX,
         DragElement, IconChevronDown,
         Float,

--- a/resources/js/Pages/Projects/Components/SingleRelevantEvent.vue
+++ b/resources/js/Pages/Projects/Components/SingleRelevantEvent.vue
@@ -65,9 +65,9 @@
                             dots-size="h-4 w-4"
                             menu-width="w-fit"
                         >
-                            <BaseMenuItem white-menu-background title="Delete shift planning" icon="IconTrash" @click="openDeleteConfirmModal" />
-                            <BaseMenuItem white-menu-background title="Save shift planning as a template" icon="IconFilePlus" @click="saveShiftAsPreset" />
-                            <BaseMenuItem white-menu-background title="Import shift planning from template" icon="IconFileImport" @click="showImportShiftTemplateModal = true" />
+                            <BaseMenuItem white-menu-background title="Delete shift planning" :icon="IconTrash" @click="openDeleteConfirmModal" />
+                            <BaseMenuItem white-menu-background title="Save shift planning as a template" :icon="IconFilePlus" @click="saveShiftAsPreset" />
+                            <BaseMenuItem white-menu-background title="Import shift planning from template" :icon="IconFileImport" @click="showImportShiftTemplateModal = true" />
                         </BaseMenu>
                     </div>
                 </div>
@@ -125,7 +125,7 @@ import AddShiftPresetModal from '@/Pages/Projects/Components/AddShiftPresetModal
 import ImportShiftTemplate from '@/Pages/Projects/Components/ImportShiftTemplate.vue'
 import TimeLineShiftsComponent from '@/Pages/Projects/Components/TimeLineShiftsComponent.vue'
 import { ChevronDownIcon, ChevronUpIcon } from '@heroicons/vue/outline'
-import {IconRepeat} from '@tabler/icons-vue'// falls du ein eigenes Icon nutzt – ansonsten ersetzen/entfernen
+import {IconFileImport, IconFilePlus, IconRepeat, IconTrash} from '@tabler/icons-vue'// falls du ein eigenes Icon nutzt – ansonsten ersetzen/entfernen
 import { useColorHelper } from '@/Composeables/UseColorHelper.js' // enthält backgroundColorWithOpacity & getTextColorBasedOnBackground
 
 defineOptions({ name: 'SingleRelevantEvent' })

--- a/resources/js/Pages/Projects/Components/SingleShift.vue
+++ b/resources/js/Pages/Projects/Components/SingleShift.vue
@@ -45,9 +45,9 @@
                     v-if="can('can plan shifts') || isAdmin"
                     dots-size="h-5 w-5 text-white"
                 >
-                    <BaseMenuItem white-menu-background title="Edit" icon="IconEdit" @click="editShift" />
-                    <BaseMenuItem white-menu-background title="Clear" icon="IconCircleX" @click="clearShiftUsers(shift)" />
-                    <BaseMenuItem white-menu-background title="Delete" icon="IconTrash" @click="deleteShift(shift.id)" />
+                    <BaseMenuItem white-menu-background title="Edit" :icon="IconEdit" @click="editShift" />
+                    <BaseMenuItem white-menu-background title="Clear" :icon="IconCircleX" @click="clearShiftUsers(shift)" />
+                    <BaseMenuItem white-menu-background title="Delete" :icon="IconTrash" @click="deleteShift(shift.id)" />
                 </BaseMenu>
             </div>
 
@@ -264,7 +264,7 @@
             <!-- Add Qualification -->
             <div class="my-3 mx-0.5" v-if="canEditComponent">
                 <component
-                    is="IconCirclePlus"
+                    :is="IconCirclePlus"
                     @click="showAddShiftQualificationModal = true"
                     class="h-5 w-5 xsLight cursor-pointer hover:text-artwork-buttons-hover transition-colors"
                     stroke-width="1.5"
@@ -309,7 +309,7 @@ import ShiftsQualificationsDropElement from '@/Pages/Projects/Components/ShiftsQ
 import AddShiftModal from '@/Pages/Projects/Components/AddShiftModal.vue'
 import AddShiftQualificationToShiftModel from '@/Pages/Projects/Components/AddShiftQualificationToShiftModel.vue'
 import BaseInput from '@/Artwork/Inputs/BaseInput.vue'
-import {IconX} from "@tabler/icons-vue";
+import {IconCirclePlus, IconCircleX, IconEdit, IconTrash, IconX} from "@tabler/icons-vue";
 
 defineOptions({ name: 'SingleShift' })
 

--- a/resources/js/Pages/Projects/Components/Timeline.vue
+++ b/resources/js/Pages/Projects/Components/Timeline.vue
@@ -22,7 +22,7 @@
             <div class="flex items-center gap-2">
                 <ToolTipComponent
                     v-if="canEditComponent"
-                    icon="IconClipboard"
+                    :icon="IconClipboard"
                     icon-size="w-5 h-5"
                     white-icon
                     :tooltip-text="$t('Copy timeline to clipboard')"
@@ -31,7 +31,7 @@
                 />
                 <ToolTipComponent
                     v-if="canEditComponent"
-                    icon="IconWand"
+                    :icon="IconWand"
                     icon-size="w-5 h-5"
                     white-icon
                     :tooltip-text="$t('Create new timeline')"
@@ -39,9 +39,9 @@
                     direction="bottom"
                 />
                 <BaseMenu v-if="canEditComponent" white-menu-background has-no-offset white-icon>
-                    <BaseMenuItem white-menu-background title="Read from template" icon="IconFileImport" @click="showSearchTimelinePresetModal = true" />
-                    <BaseMenuItem white-menu-background title="Save as template" icon="IconFileExport" @click="showCreateTimelinePresetModal = true" />
-                    <BaseMenuItem white-menu-background title="Edit" @click="openTimelineModal(true)" />
+                    <BaseMenuItem white-menu-background title="Read from template" :icon="IconFileImport" @click="showSearchTimelinePresetModal = true" />
+                    <BaseMenuItem white-menu-background title="Save as template" :icon="IconFileExport" @click="showCreateTimelinePresetModal = true" />
+                    <BaseMenuItem white-menu-background title="Edit" :icon="IconEdit" @click="openTimelineModal(true)" />
                 </BaseMenu>
             </div>
         </div>
@@ -68,7 +68,7 @@
                     @click="addEmptyTimeline"
                 >
                     <component
-                        is="IconCircleDashedPlus"
+                        :is="IconCircleDashedPlus"
                         class="h-6 w-6 text-artwork-buttons-context/40 group-hover:text-artwork-buttons-hover transition-colors"
                         stroke-width="1.5"
                         aria-hidden="true"
@@ -129,7 +129,15 @@ import ToolTipComponent from '@/Components/ToolTips/ToolTipComponent.vue'
 import SearchTimelinePresetModal from '@/Pages/Projects/Components/TimelineComponents/SearchTimelinePresetModal.vue'
 import CreateTimelinePresetFormEvent from '@/Pages/Projects/Components/TimelineComponents/CreateTimelinePresetFormEvent.vue'
 import {is, can} from "laravel-permission-to-vuejs";
-import {IconX} from "@tabler/icons-vue";
+import {
+    IconCircleDashedPlus,
+    IconClipboard,
+    IconEdit,
+    IconFileExport,
+    IconFileImport,
+    IconWand,
+    IconX
+} from "@tabler/icons-vue";
 
 defineOptions({ name: 'Timeline' })
 

--- a/resources/js/Pages/Projects/Components/TimelineComponents/NewSingleTimeline.vue
+++ b/resources/js/Pages/Projects/Components/TimelineComponents/NewSingleTimeline.vue
@@ -75,8 +75,8 @@
             </div>
             <div class="invisible group-hover:visible" v-if="!time.clicked || editDescription">
                 <BaseMenu v-if="canEditComponent" white-menu-background has-no-offset>
-                    <BaseMenuItem white-menu-background title="Edit" @click="openCloseTimeEditor(true)" />
-                    <BaseMenuItem white-menu-background title="Delete" icon="IconTrash" @click="deleteTime" />
+                    <BaseMenuItem white-menu-background title="Edit" :icon="IconEdit" @click="openCloseTimeEditor(true)" />
+                    <BaseMenuItem white-menu-background title="Delete" :icon="IconTrash" @click="deleteTime" />
                 </BaseMenu>
             </div>
         </div>
@@ -91,7 +91,7 @@ import {usePermission} from "@/Composeables/Permission.js";
 import {router, useForm, usePage} from "@inertiajs/vue3";
 import TimeInputComponent from "@/Components/Inputs/TimeInputComponent.vue";
 const {hasAdminRole, can} = usePermission(usePage().props)
-import {IconCircleCheck, IconNote, IconTrash} from '@tabler/icons-vue';
+import {IconCircleCheck, IconEdit, IconNote, IconTrash} from '@tabler/icons-vue';
 import timeline from "@/Pages/Projects/Components/Timeline.vue";
 import {nextTick, ref, watch} from "vue";
 import TextareaComponent from "@/Components/Inputs/TextareaComponent.vue";

--- a/resources/js/Pages/Projects/NewProjectManagement.vue
+++ b/resources/js/Pages/Projects/NewProjectManagement.vue
@@ -14,7 +14,7 @@
                                 <div class="flex items-center">
                                     <div v-if="!showSearchbar" @click="openSearchbar"
                                          class="cursor-pointer inset-y-0">
-                                        <ToolTipComponent icon="IconSearch" icon-size="h-7 w-7" :tooltip-text="$t('Search')"
+                                        <ToolTipComponent :icon="IconSearch" icon-size="h-7 w-7" :tooltip-text="$t('Search')"
                                                           direction="bottom"/>
                                     </div>
                                     <div v-else class="w-96">
@@ -127,7 +127,7 @@
                                         </div>
                                     </MenuItem>
                                 </BaseMenu>
-                                <ToolTipComponent icon="IconFileExport"
+                                <ToolTipComponent :icon="IconFileExport"
                                                   icon-size="h-7 w-7"
                                                   :tooltip-text="$t('Export project list')"
                                                   direction="bottom"
@@ -277,7 +277,16 @@ import AppLayout from "@/Layouts/AppLayout.vue";
 import {Link, router, usePage} from "@inertiajs/vue3";
 import BaseMenu from "@/Components/Menu/BaseMenu.vue";
 import BaseFilter from "@/Layouts/Components/BaseFilter.vue";
-import {IconCheck, IconChevronDown, IconChevronUp, IconGeometry, IconPlus, IconX} from "@tabler/icons-vue";
+import {
+    IconCheck,
+    IconChevronDown,
+    IconChevronUp,
+    IconFileExport,
+    IconGeometry,
+    IconPlus,
+    IconSearch,
+    IconX
+} from "@tabler/icons-vue";
 import Input from "@/Jetstream/Input.vue";
 import PlusButton from "@/Layouts/Components/General/Buttons/PlusButton.vue";
 import SvgCollection from "@/Layouts/Components/SvgCollection.vue";

--- a/resources/js/Pages/Projects/ProjectManagement.vue
+++ b/resources/js/Pages/Projects/ProjectManagement.vue
@@ -13,7 +13,7 @@
                             <div class="flex items-center">
                                 <div v-if="!showSearchbar" @click="openSearchbar"
                                      class="cursor-pointer inset-y-0">
-                                    <ToolTipComponent icon="IconSearch" icon-size="h-7 w-7" :tooltip-text="$t('Search')"
+                                    <ToolTipComponent :icon="IconSearch" icon-size="h-7 w-7" :tooltip-text="$t('Search')"
                                                       direction="bottom"/>
                                 </div>
                                 <div v-else class="flex items-center w-60">
@@ -123,7 +123,7 @@
                                     </div>
                                 </MenuItem>
                             </BaseMenu>
-                            <ToolTipComponent icon="IconFileExport"
+                            <ToolTipComponent :icon="IconFileExport"
                                               icon-size="h-7 w-7"
                                               :tooltip-text="$t('Export project list')"
                                               direction="bottom"
@@ -323,7 +323,7 @@ import BaseMenu from "@/Components/Menu/BaseMenu.vue";
 import AddButtonSmall from "@/Layouts/Components/General/Buttons/AddButtonSmall.vue";
 import BaseButton from "@/Layouts/Components/General/Buttons/BaseButton.vue";
 import SuccessModal from "@/Layouts/Components/General/SuccessModal.vue";
-import {IconCheck, IconPin} from "@tabler/icons-vue";
+import {IconCheck, IconFileExport, IconPin, IconSearch} from "@tabler/icons-vue";
 import ProjectCreateModal from "@/Layouts/Components/ProjectCreateModal.vue";
 import ProjectDataEditModal from "@/Layouts/Components/ProjectDataEditModal.vue";
 import UserPopoverTooltip from "@/Layouts/Components/UserPopoverTooltip.vue";
@@ -510,6 +510,8 @@ export default defineComponent({
         }
     },
     methods: {
+        IconFileExport,
+        IconSearch,
         usePage,
         getSortEnumTranslation,
         openCreateProjectModal() {

--- a/resources/js/Pages/Projects/Tab/Components/ArtistResidenciesComponent.vue
+++ b/resources/js/Pages/Projects/Tab/Components/ArtistResidenciesComponent.vue
@@ -6,7 +6,7 @@
             </div>
             <div class="mt-4 sm:ml-16 sm:mt-0 sm:flex-none flex items-center gap-x-4 print:hidden">
                 <ToolTipComponent
-                    icon="IconFileExport"
+                    :icon="IconFileExport"
                     :tooltip-text="$t('Export artist management')"
                     direction="bottom"
                     @click="openExportArtistResidenciesModal = true"
@@ -78,7 +78,7 @@
 import TinyPageHeadline from "@/Components/Headlines/TinyPageHeadline.vue";
 import AddButtonSmall from "@/Layouts/Components/General/Buttons/AddButtonSmall.vue";
 import BaseMenu from "@/Components/Menu/BaseMenu.vue";
-import {IconBuildingSkyscraper, IconEdit, IconMoneybag} from "@tabler/icons-vue";
+import {IconBuildingSkyscraper, IconEdit, IconFileExport, IconMoneybag} from "@tabler/icons-vue";
 import {MenuItem} from "@headlessui/vue";
 import AddEditArtistResidenciesModal
     from "@/Pages/Projects/Components/ArtistResidenciesComponents/AddEditArtistResidenciesModal.vue";

--- a/resources/js/Pages/Projects/Tab/Components/LinkComponent.vue
+++ b/resources/js/Pages/Projects/Tab/Components/LinkComponent.vue
@@ -5,6 +5,7 @@ import {reactive, ref} from "vue";
 import InfoButtonComponent from "@/Pages/Projects/Tab/Components/InfoButtonComponent.vue";
 import BaseInput from "@/Artwork/Inputs/BaseInput.vue";
 import {Link} from "@inertiajs/vue3";
+import {IconEdit} from "@tabler/icons-vue";
 
 export default {
     name: "TextField",
@@ -30,6 +31,7 @@ export default {
         useProjectDataListener(this.projectData, this.projectId).init();
     },
     methods: {
+        IconEdit,
         updateTextData() {
             this.$inertia.patch(route('project.tab.component.update', {project: this.projectId, component: this.data.id}), {
                 data: {
@@ -64,7 +66,7 @@ export default {
                     {{ projectData.data.label }}
                 </label>
 
-                <component is="IconEdit" class="inline size-4 ml-2 cursor-pointer text-gray-400 hover:text-gray-600" v-if="canEditComponent" @click="showTextField = !showTextField" />
+                <component :is="IconEdit" class="inline size-4 ml-2 cursor-pointer text-gray-400 hover:text-gray-600" v-if="canEditComponent" @click="showTextField = !showTextField" />
             </div>
             <div class="mt-2 w-96" v-if="showTextField">
                 <BaseInput

--- a/resources/js/Pages/Projects/Tab/Components/ProjectHeaderComponent.vue
+++ b/resources/js/Pages/Projects/Tab/Components/ProjectHeaderComponent.vue
@@ -155,6 +155,7 @@
                                         v-if="is('artwork admin') || headerObject.projectWriteIds.includes(usePage().props.auth.user.id) || headerObject.projectManagerIds.includes(usePage().props.auth.user.id) || can('write projects')"
                                         @click="openEditProjectModal"
                                         title="Edit basic data"
+                                        :icon="IconEdit"
                                     />
                                     <div v-if="project.is_group">
                                         <BaseMenuItem
@@ -172,12 +173,12 @@
                                             title="Create project in this group"
                                         />
                                     </div>
-                                    <BaseMenuItem white-menu-background @click="duplicateProject(this.project)" icon="IconCopy" title="Duplicate" />
+                                    <BaseMenuItem white-menu-background @click="duplicateProject(this.project)" :icon="IconCopy" title="Duplicate" />
                                     <BaseMenuItem
                                         white-menu-background
                                         v-if="headerObject.projectDeleteIds.includes(usePage().props.auth.user.id) || is('artwork admin')"
                                         @click="openDeleteProjectModal(project)"
-                                        icon="IconTrash"
+                                        :icon="IconTrash"
                                         title="Put in the trash"
                                     />
                                 </BaseMenu>
@@ -337,9 +338,9 @@ import {
     IconAlertSquareRounded,
     IconChevronRight,
     IconCirclePlus,
-    IconClipboard,
+    IconClipboard, IconCopy, IconEdit,
     IconLink,
-    IconPrinter,
+    IconPrinter, IconTrash,
     IconX
 } from "@tabler/icons-vue";
 

--- a/resources/js/Pages/Projects/Tab/Components/ShiftTab.vue
+++ b/resources/js/Pages/Projects/Tab/Components/ShiftTab.vue
@@ -91,7 +91,7 @@
                             ref="userWindowButton"
                             @click="openUserWindow"
                         >
-                            <ToolTipComponent icon="IconUsers" :tooltip-text="$t('Users')" direction="left" :stroke="1.5" />
+                            <ToolTipComponent :icon="IconUsers" :tooltip-text="$t('Users')" direction="left" :stroke="1.5" />
                         </div>
                     </div>
                 </div>
@@ -315,7 +315,7 @@ import SingleRelevantEvent from '@/Pages/Projects/Components/SingleRelevantEvent
 import { useSortEnumTranslation } from '@/Composeables/SortEnumTranslation.js'
 
 
-import { IconFilter, IconSearch, IconX, IconCheck, IconChevronDown, IconChevronUp } from '@tabler/icons-vue'
+import {IconFilter, IconSearch, IconX, IconCheck, IconChevronDown, IconChevronUp, IconUsers} from '@tabler/icons-vue'
 
 defineOptions({ name: 'ShiftTab' })
 

--- a/resources/js/Pages/Settings/ComponentManagement/Index.vue
+++ b/resources/js/Pages/Settings/ComponentManagement/Index.vue
@@ -12,7 +12,7 @@
                 <div class="flex items-center justify-end w-full mb-3">
                     <div class="flex items-center gap-x-5">
                         <div>
-                            <GlassyIconButton icon="IconPlus" @click="showAddNewComponentModal = true" :text="$t('Create a new component')"/>
+                            <GlassyIconButton :icon="IconPlus" @click="showAddNewComponentModal = true" :text="$t('Create a new component')"/>
                         </div>
                         <div class="w-44 md:w-56 lg:w-72">
                             <div>
@@ -66,9 +66,11 @@ import ComponentModal from "@/Pages/Settings/ComponentManagement/Components/Comp
 import DropComponentsToolTip from "@/Components/ToolTips/DropComponentsToolTip.vue";
 import GlassyIconButton from "@/Artwork/Buttons/GlassyIconButton.vue";
 import BaseInput from "@/Artwork/Inputs/BaseInput.vue";
+import {IconPlus} from "@tabler/icons-vue";
 
 export default {
     name: "Index",
+    methods: {IconPlus},
     components: {
         BaseInput,
         GlassyIconButton,

--- a/resources/js/Pages/Settings/Components/Sidebar/SingleSidebarElement.vue
+++ b/resources/js/Pages/Settings/Components/Sidebar/SingleSidebarElement.vue
@@ -117,8 +117,8 @@ function removeTab() {
             </button>
 
             <BaseMenu has-no-offset white-menu-background>
-                <BaseMenuItem white-menu-background icon="IconEdit" title="Edit" @click="editTab" />
-                <BaseMenuItem white-menu-background icon="IconTrash" title="Delete" @click="removeTab" />
+                <BaseMenuItem white-menu-background :icon="IconEdit" title="Edit" @click="editTab" />
+                <BaseMenuItem white-menu-background :icon="IconTrash" title="Delete" @click="removeTab" />
             </BaseMenu>
 
         </div>
@@ -180,7 +180,7 @@ function removeTab() {
                                 <IconDragDrop class="h-5 w-5 text-zinc-400 invisible group-hover:visible" aria-hidden="true" />
                                 <div class="invisible group-hover:visible">
                                     <BaseMenu has-no-offset white-menu-background>
-                                        <BaseMenuItem white-menu-background icon="IconTrash" title="Delete" @click="removeComponentFromSidebar(element.id)" />
+                                        <BaseMenuItem white-menu-background :icon="IconTrash" title="Delete" @click="removeComponentFromSidebar(element.id)" />
                                     </BaseMenu>
                                 </div>
                             </div>

--- a/resources/js/Pages/Settings/Components/SingleTabComponent.vue
+++ b/resources/js/Pages/Settings/Components/SingleTabComponent.vue
@@ -129,8 +129,8 @@ function updateDefaultTab() {
 
                     <!-- Menü -->
                     <BaseMenu has-no-offset white-menu-background>
-                        <BaseMenuItem icon="IconEdit" title="Edit" @click="editTab" white-menu-background />
-                        <BaseMenuItem icon="IconTrash" title="Delete" @click="removeTab" white-menu-background />
+                        <BaseMenuItem :icon="IconEdit" title="Edit" @click="editTab" white-menu-background />
+                        <BaseMenuItem :icon="IconTrash" title="Delete" @click="removeTab" white-menu-background />
                     </BaseMenu>
                 </div>
             </div>

--- a/resources/js/Pages/Settings/DayServiceIndex.vue
+++ b/resources/js/Pages/Settings/DayServiceIndex.vue
@@ -5,11 +5,13 @@ import AddButtonSmall from "@/Layouts/Components/General/Buttons/AddButtonSmall.
 import AddEditDayServiceModal from "@/Pages/Settings/Components/AddEditDayServiceModal.vue";
 import IconLib from "@/Mixins/IconLib.vue";
 import GlassyIconButton from "@/Artwork/Buttons/GlassyIconButton.vue";
+import {IconPlus} from "@tabler/icons-vue";
+import PropertyIcon from "@/Artwork/Icon/PropertyIcon.vue";
 
 export default {
     name: "DayServiceIndex",
     mixins: [IconLib],
-    components: {GlassyIconButton, AddEditDayServiceModal, AddButtonSmall, TabComponent, AppLayout},
+    components: {PropertyIcon, GlassyIconButton, AddEditDayServiceModal, AddButtonSmall, TabComponent, AppLayout},
     props: [
         'dayServices'
     ],
@@ -70,6 +72,7 @@ export default {
         }
     },
     methods: {
+        IconPlus,
         closeModal(){
             this.showAddEditDayServiceModal = false;
             this.dayServiceToEdit = null;
@@ -95,7 +98,7 @@ export default {
            <div class="flex items-center justify-between">
                <TabComponent :tabs="tabs" />
 
-               <GlassyIconButton text="New Day Service" icon="IconPlus"@click="showAddEditDayServiceModal = true" />
+               <GlassyIconButton text="New Day Service" :icon="IconPlus"@click="showAddEditDayServiceModal = true" />
            </div>
 
             <div class="my-5 card white p-5" >
@@ -103,7 +106,7 @@ export default {
                     <div class="grid grid-cols-1 md:grid-cols-3 xl:grid-cols-8 mb-3">
                         <div class="col-span-full md:col-span-2 xl:col-span-7">
                             <div class="flex items-center gap-x-1.5">
-                                <Component :is="dayService.icon" stroke-width="1.5" :style="{color: dayService.hex_color}" class="h-8 w-8 cursor-pointer flex items-center text-black" />
+                                <PropertyIcon :name="dayService.icon" stroke-width="1.5" :style="{color: dayService.hex_color}" class="h-8 w-8 cursor-pointer flex items-center text-black" />
                                 <div class="">{{ dayService.name }}</div>
                             </div>
                         </div>

--- a/resources/js/Pages/Settings/EventProperties/Index.vue
+++ b/resources/js/Pages/Settings/EventProperties/Index.vue
@@ -6,7 +6,7 @@
                     <TinyPageHeadline title="Event Eigenschaften"
                                       description="Hier kannst du die Event Eigenschaften verwalten."/>
                     <div>
-                        <GlassyIconButton icon="IconPlus" @click="showEventPropertyModal = true;" text="Event Eigenschaft hinzufügen"/>
+                        <GlassyIconButton :icon="IconPlus" @click="showEventPropertyModal = true;" text="Event Eigenschaft hinzufügen"/>
                     </div>
                 </div>
                 <ul role="list" class="flex flex-col gap-y-3">
@@ -14,9 +14,9 @@
                         :key="eventProperty.id"
                         class="flex flex-row justify-between">
                         <div class="flex flex-row items-center gap-4">
-                            <component as="div" class="h-12 w-12 rounded-full border border-gray-300 p-2"
+                            <PropertyIcon as="div" class="h-12 w-12 rounded-full border border-gray-300 p-2"
                                        width="16" height="16"
-                                       :is="eventProperty.icon"
+                                       :name="eventProperty.icon"
                                        stroke-width="1.5"/>
                             <p class="mDark">{{ eventProperty.name }}</p>
                         </div>
@@ -77,6 +77,8 @@ import {router} from "@inertiajs/vue3";
 import {provide} from "vue";
 import IconSelector from "@/Components/Icon/IconSelector.vue";
 import GlassyIconButton from "@/Artwork/Buttons/GlassyIconButton.vue";
+import {IconPlus} from "@tabler/icons-vue";
+import PropertyIcon from "@/Artwork/Icon/PropertyIcon.vue";
 
 const props = defineProps({
         event_properties: {

--- a/resources/js/Pages/Settings/EventSettings.vue
+++ b/resources/js/Pages/Settings/EventSettings.vue
@@ -5,7 +5,7 @@
                <div>
                    <div class="flex items-center justify-between mb-5">
                        <h2 class="headline2 my-2">{{$t('Event Types')}}</h2>
-                       <GlassyIconButton icon="IconPlus" @click="openAddEventTypeModal" :text="$t('New Event Type')"/>
+                       <GlassyIconButton :icon="IconPlus" @click="openAddEventTypeModal" :text="$t('New Event Type')"/>
                        <div v-if="this.$page.props.show_hints" class="flex mt-1">
                            <SvgCollection svgName="arrowLeft" class="mt-1 ml-2"/>
                            <span class="hind ml-1 my-auto">{{$t('Create new Event Types')}}</span>
@@ -53,8 +53,8 @@
                        </div>
                        <div class="flex items-center">
                            <BaseMenu has-no-offset white-menu-background>
-                               <BaseMenuItem title="Edit event type" white-menu-background @click="openEditEventTypeModal(eventType)" />
-                               <BaseMenuItem v-if="index !== 0" title="Delete event type" icon="IconTrash" white-menu-background @click="openDeleteEventTypeModal(eventType)" />
+                               <BaseMenuItem title="Edit event type" :icon="IconEdit" white-menu-background @click="openEditEventTypeModal(eventType)" />
+                               <BaseMenuItem v-if="index !== 0" title="Delete event type" :icon="IconTrash" white-menu-background @click="openDeleteEventTypeModal(eventType)" />
                            </BaseMenu>
                        </div>
                    </li>
@@ -103,6 +103,7 @@ import GlassyIconButton from "@/Artwork/Buttons/GlassyIconButton.vue";
 import DeleteEventTypeConfirmationModal from "@/Pages/Settings/EventType/Components/Modals/DeleteEventTypeConfirmationModal.vue";
 import DeleteStandardEventTypeModal from "@/Pages/Settings/EventType/Components/Modals/DeleteStandardEventTypeModal.vue";
 import BaseMenuItem from "@/Components/Menu/BaseMenuItem.vue";
+import {IconEdit, IconPlus, IconTrash} from "@tabler/icons-vue";
 export default {
     mixins: [Permissions],
     computed: {
@@ -204,6 +205,9 @@ export default {
         }
     },
     methods: {
+        IconTrash,
+        IconEdit,
+        IconPlus,
         addColor(color) {
             this.eventTypeForm.hex_code = color;
         },

--- a/resources/js/Pages/Settings/ProjectManagementBuilder/Components/SingleComponentInGrid.vue
+++ b/resources/js/Pages/Settings/ProjectManagementBuilder/Components/SingleComponentInGrid.vue
@@ -9,7 +9,7 @@
 
             <div class="flex items-center" v-if="element.deletable">
                 <BaseMenu has-no-offset>
-                    <BaseMenuItem title="Delete" icon="IconTrash" @click="showDeleteConfirmationModal = true" />
+                    <BaseMenuItem title="Delete" :icon="IconTrash" @click="showDeleteConfirmationModal = true" />
                 </BaseMenu>
             </div>
         </div>
@@ -30,6 +30,7 @@ import BaseMenuItem from "@/Components/Menu/BaseMenuItem.vue";
 import ConfirmDeleteModal from "@/Layouts/Components/ConfirmDeleteModal.vue";
 import {ref} from "vue";
 import {router} from "@inertiajs/vue3";
+import {IconTrash} from "@tabler/icons-vue";
 
 const props = defineProps({
     element: {

--- a/resources/js/Pages/Settings/ProjectPrintLayout/Index.vue
+++ b/resources/js/Pages/Settings/ProjectPrintLayout/Index.vue
@@ -16,7 +16,7 @@
                 <!-- Tab components -->
                 <div class="w-full col-span-1">
                     <div class="flex justify-end mb-5">
-                        <GlassyIconButton icon="IconPlus" @click="showCreateOrUpdateModal = true" :text="$t('Create tab')" />
+                        <GlassyIconButton :icon="IconPlus" @click="showCreateOrUpdateModal = true" :text="$t('Create tab')" />
                     </div>
 
 

--- a/resources/js/Pages/Settings/ProjectRoles.vue
+++ b/resources/js/Pages/Settings/ProjectRoles.vue
@@ -9,7 +9,7 @@
             </div>
             <ProjectTabs />
             <div class="flex items-center justify-end mb-5">
-                <GlassyIconButton @click="showAddProjectRoleModal = true" icon="IconPlus" :text="$t('Add Project Role')"/>
+                <GlassyIconButton @click="showAddProjectRoleModal = true" :icon="IconPlus" :text="$t('Add Project Role')"/>
             </div>
             <div v-for="role in projectRoles">
                 <div class="rounded-lg bg-gray-50 px-4 py-5 mb-3">
@@ -53,6 +53,7 @@ import ModalHeader from "@/Components/Modals/ModalHeader.vue";
 import TextInputComponent from "@/Components/Inputs/TextInputComponent.vue";
 import BaseInput from "@/Artwork/Inputs/BaseInput.vue";
 import GlassyIconButton from "@/Artwork/Buttons/GlassyIconButton.vue";
+import {IconPlus} from "@tabler/icons-vue";
 
 export default {
     name: "ProjectRoles",
@@ -77,6 +78,7 @@ export default {
         }
     },
     methods: {
+        IconPlus,
         closeAddProjectRoleModal() {
             this.showAddProjectRoleModal = false;
         },

--- a/resources/js/Pages/Settings/ProjectTab/Index.vue
+++ b/resources/js/Pages/Settings/ProjectTab/Index.vue
@@ -12,6 +12,7 @@ import BaseInput from "@/Artwork/Inputs/BaseInput.vue";
 import { computed, ref, watch } from "vue";
 import { router } from "@inertiajs/vue3";
 import { useI18n } from "vue-i18n";
+import {IconPlus} from "@tabler/icons-vue";
 
 // Props
 const props = defineProps({
@@ -99,7 +100,7 @@ function updateComponentOrder(components) {
                 <div class="w-full col-span-1">
                     <div class="flex justify-end mb-5">
                         <GlassyIconButton
-                            icon="IconPlus"
+                            :icon="IconPlus"
                             @click="showAddEditModal = true"
                             :text="t('Create tab')"
                         />

--- a/resources/js/Pages/Settings/ShiftSettings.vue
+++ b/resources/js/Pages/Settings/ShiftSettings.vue
@@ -72,7 +72,7 @@
                         />
                     </div>
                     <div class="flex items-center justify-end">
-                        <GlassyIconButton text="New Craft" icon="IconPlus" @click="openAddCraftsModal = true" />
+                        <GlassyIconButton text="New Craft" :icon="IconPlus" @click="openAddCraftsModal = true" />
                     </div>
                 </div>
                 <draggable ghost-class="opacity-50" key="draggableKey" item-key="id" :list="crafts" @start="dragging=true" @end="dragging=false" @change="reorderCrafts(crafts)">
@@ -185,7 +185,7 @@
                         :title="$t('Qualifications')"
                         :description="$t('Create or edit qualifications')"
                     />
-                    <GlassyIconButton text="Neue Qualifikation" icon="IconPlus" @click="this.openShiftQualificationModal('create')" />
+                    <GlassyIconButton text="Neue Qualifikation" :icon="IconPlus" @click="this.openShiftQualificationModal('create')" />
                 </div>
                 <div class="mt-5">
                     <div class="mb-5 xsLight" v-if="shiftQualifications.length === 0">

--- a/resources/js/Pages/Settings/UserContractSettings/Components/SingleUserContractTemplate.vue
+++ b/resources/js/Pages/Settings/UserContractSettings/Components/SingleUserContractTemplate.vue
@@ -19,8 +19,8 @@
     </div>
     <div class="flex shrink-0 items-center gap-x-6">
         <BaseMenu has-no-offset white-menu-background>
-            <BaseMenuItem title="Edit" white-menu-background icon="IconEdit" @click="showCreateOrUpdateUserContractModal = true"/>
-            <BaseMenuItem title="Delete" white-menu-background icon="IconTrash" @click="showDeleteModal = true"/>
+            <BaseMenuItem title="Edit" white-menu-background :icon="IconEdit" @click="showCreateOrUpdateUserContractModal = true"/>
+            <BaseMenuItem title="Delete" white-menu-background :icon="IconTrash" @click="showDeleteModal = true"/>
         </BaseMenu>
     </div>
 
@@ -45,6 +45,7 @@ import BaseMenu from "@/Components/Menu/BaseMenu.vue";
 import BaseMenuItem from "@/Components/Menu/BaseMenuItem.vue";
 import {defineAsyncComponent, ref} from "vue";
 import {router} from "@inertiajs/vue3";
+import {IconEdit, IconTrash} from "@tabler/icons-vue";
 
 const props = defineProps({
     contract: {

--- a/resources/js/Pages/Settings/WorkTimePattern/Components/SingleWorkTimePattern.vue
+++ b/resources/js/Pages/Settings/WorkTimePattern/Components/SingleWorkTimePattern.vue
@@ -21,8 +21,8 @@
     </div>
     <div class="flex shrink-0 items-center gap-x-6">
         <BaseMenu has-no-offset white-menu-background>
-            <BaseMenuItem title="Edit" white-menu-background icon="IconEdit" @click="showCreateOrUpdateWorkTimePatternModal = true"/>
-            <BaseMenuItem title="Delete" white-menu-background icon="IconTrash" @click="showDeleteModal = true"/>
+            <BaseMenuItem title="Edit" white-menu-background :icon="IconEdit" @click="showCreateOrUpdateWorkTimePatternModal = true"/>
+            <BaseMenuItem title="Delete" white-menu-background :icon="IconTrash" @click="showDeleteModal = true"/>
         </BaseMenu>
     </div>
 
@@ -47,6 +47,7 @@ import BaseMenu from "@/Components/Menu/BaseMenu.vue";
 import BaseMenuItem from "@/Components/Menu/BaseMenuItem.vue";
 import {defineAsyncComponent, ref} from "vue";
 import {router} from "@inertiajs/vue3";
+import {IconEdit, IconTrash} from "@tabler/icons-vue";
 
 const props = defineProps({
     workTimePattern: {

--- a/resources/js/Pages/Shifts/Components/MultiEditUserCell.vue
+++ b/resources/js/Pages/Shifts/Components/MultiEditUserCell.vue
@@ -40,7 +40,7 @@
                 <div class="flex items-center justify-end w-fit gap-2 absolute right-2 top-2">
                     <div v-if="type === 0 && item.is_freelancer || type === 1">
                         <ToolTipComponent
-                            icon="IconId"
+                            :icon="IconId"
                             icon-size="w-4 h-4"
                             tooltip-text="Freelancer*in"
                             direction="top"
@@ -62,7 +62,7 @@
 import {defineComponent} from 'vue'
 import ColorHelper from "@/Mixins/ColorHelper.vue";
 import ToolTipComponent from "@/Components/ToolTips/ToolTipComponent.vue";
-import {IconCalendarShare} from "@tabler/icons-vue";
+import {IconCalendarShare, IconId} from "@tabler/icons-vue";
 
 export default defineComponent({
     name: "MultiEditUserCell",
@@ -119,6 +119,7 @@ export default defineComponent({
         }
     },
     methods: {
+        IconId,
         changeUserForMultiEdit(event) {
             if (!event.target.checked) {
                 this.$emit('addUserToMultiEdit', null);

--- a/resources/js/Pages/Shifts/DailyViewComponents/SingleEntityInShift.vue
+++ b/resources/js/Pages/Shifts/DailyViewComponents/SingleEntityInShift.vue
@@ -29,7 +29,7 @@
                                 id="start" type="time" class="max-w-28 text-xs"
                                 v-model="person.pivot.end_time"
                             />
-                            <GlassyIconButton text="Save" icon="IconDeviceFloppy" icon-size="size-4" @click.stop="saveIndividualShiftTime(close)"/>
+                            <GlassyIconButton text="Save" :icon="IconDeviceFloppy" icon-size="size-4" @click.stop="saveIndividualShiftTime(close)"/>
                         </div>
                     </div>
                 </PopoverPanel>
@@ -59,7 +59,7 @@
         </div>
 
         <div class="flex items-center gap-x-1 col-span-1">
-            <component :is="findShiftQualification(person.pivot?.shift_qualification_id)?.icon" class="size-3" />
+            <PropertyIcon :name="findShiftQualification(person.pivot?.shift_qualification_id)?.icon" class="size-3" />
             {{ findShiftQualification(person.pivot?.shift_qualification_id)?.name }}
         </div>
         <div class=" col-span-2">
@@ -125,6 +125,7 @@ import RequestWorkTimeChangeModal from "@/Pages/Shifts/Components/RequestWorkTim
 import {computed, ref} from "vue";
 import {IconDeviceFloppy, IconNote, IconX} from "@tabler/icons-vue";
 import {can, is} from "laravel-permission-to-vuejs";
+import PropertyIcon from "@/Artwork/Icon/PropertyIcon.vue";
 
 const props = defineProps({
     person: {

--- a/resources/js/Pages/Shifts/DailyViewComponents/SingleEventInDailyShiftView.vue
+++ b/resources/js/Pages/Shifts/DailyViewComponents/SingleEventInDailyShiftView.vue
@@ -12,11 +12,11 @@
             </div>
         </div>
         <div class="flex items-center cursor-pointer justify-end gap-x-2 font-lexend px-3">
-            <component is="IconEdit"
+            <component :is="IconEdit"
                        class="size-5 text-gray-500 hover:text-gray-700 cursor-pointer transition-all duration-150 ease-in-out"
                        @click.stop="showEventComponent = true" v-if="can('can plan shifts') || is('artwork admin')" />
             <component
-                is="IconChevronDown"
+                :is="IconChevronDown"
                 class="size-5 text-gray-500 hover:text-gray-700 transition-all duration-150 ease-in-out"
                 :class="{ 'rotate-180': showEventDetails }"
                 @click="showEventDetails = !showEventDetails"
@@ -54,7 +54,7 @@
         <div class="w-full bg-gray-100 rounded-lg py-1.5 px-3 mt-1">
             <div class="text-artwork-buttons-create cursor-pointer flex items-center gap-x-1"
                 @click="showAddTimeLineModal = true">
-                <component is="IconWand" class="size-4"/>
+                <component :is="IconWand" class="size-4"/>
                 {{ event.timelines.length === 0 ? $t('Create new timeline') : $t('Edit timeline') }}
             </div>
         </div>
@@ -94,6 +94,7 @@ import UserPopoverTooltip from "@/Layouts/Components/UserPopoverTooltip.vue";
 import {usePage} from "@inertiajs/vue3";
 import {can, is} from "laravel-permission-to-vuejs";
 import EventComponent from "@/Layouts/Components/EventComponent.vue";
+import {IconChevronDown, IconEdit, IconWand} from "@tabler/icons-vue";
 
 const props = defineProps({
     event: {

--- a/resources/js/Pages/Shifts/DailyViewComponents/SingleShiftInDailyShiftView.vue
+++ b/resources/js/Pages/Shifts/DailyViewComponents/SingleShiftInDailyShiftView.vue
@@ -25,10 +25,10 @@
                 </div>
             </div>
             <div class="flex items-center justify-end px-3 gap-x-4">
-                <component is="IconEdit"
+                <component :is="IconEdit"
                            class="size-5 text-gray-500 hover:text-gray-700 cursor-pointer transition-all duration-150 ease-in-out"
                            @click.stop="showAddShiftModal = true" />
-                <component is="IconChevronDown"
+                <component :is="IconChevronDown"
                            @click.stop="toggleShiftDetails"
                            class="size-5 text-gray-500 hover:text-gray-700 cursor-pointer transition-all duration-150 ease-in-out"
                            :class="{ 'rotate-180': showShiftDetails }"/>
@@ -49,14 +49,14 @@
                         <MenuButton class="flex cursor-pointer items-center gap-x-2 font-lexend rounded-lg w-full" @click="checkShiftCollision(drop.shift_qualification_id, true)">
                             <div class="py-1.5 px-3 min-w-28 w-28 rounded-l-lg bg-red-200">
                                 <div class="text-xs text-left flex items-center gap-x-1">
-                                    <component is="IconInfoTriangle" class="size-4 text-red-600" />
+                                    <component :is="IconInfoTriangle" class="size-4 text-red-600" />
                                     {{ $t('Unoccupied') }}
                                 </div>
                             </div>
                             <div class="grid grid-cols-1 md:grid-cols-3 w-full gap-x-2">
                                 <p class="text-xs text-left">{{ drop.requiredDropElementsCount }} {{ findShiftQualification(drop.shift_qualification_id)?.name || 'Unbekannte Qualifikation' }} {{ $t('Unoccupied') }}</p>
                                 <div class="flex items-center gap-x-1">
-                                    <component :is="findShiftQualification(drop.shift_qualification_id)?.icon" class="size-3" />
+                                    <PropertyIcon :name="findShiftQualification(drop.shift_qualification_id)?.icon" class="size-3" />
                                     {{ findShiftQualification(drop.shift_qualification_id)?.name || 'Unbekannte Qualifikation' }}
                                 </div>
                             </div>
@@ -144,7 +144,15 @@ import axios from "axios";
 import SingleEntityInShift from "@/Pages/Shifts/DailyViewComponents/SingleEntityInShift.vue";
 import {can, is} from "laravel-permission-to-vuejs";
 import {useI18n} from "vue-i18n";
-import {IconAlertTriangle, IconBuildingCommunity, IconClock, IconId} from "@tabler/icons-vue";
+import {
+    IconAlertTriangle,
+    IconBuildingCommunity,
+    IconChevronDown,
+    IconClock, IconEdit,
+    IconId,
+    IconInfoTriangle
+} from "@tabler/icons-vue";
+import PropertyIcon from "@/Artwork/Icon/PropertyIcon.vue";
 
 const props = defineProps({
     shift: Object,

--- a/resources/js/Pages/Shifts/DailyViewComponents/SingleShiftInDailyShiftView.vue
+++ b/resources/js/Pages/Shifts/DailyViewComponents/SingleShiftInDailyShiftView.vue
@@ -73,7 +73,7 @@
                                         <span class="text-xs truncate w-36">{{ user.name || user.full_name }}</span>
                                         <div class="text-xs text-gray-500 flex items-center gap-x-1">
                                             <ToolTipComponent
-                                                icon="IconId"
+                                                :icon="IconId"
                                                 icon-size="w-4 h-4"
                                                 tooltip-text="Freelancer"
                                                 direction="top"
@@ -82,7 +82,7 @@
                                                 use-translation
                                             />
                                             <ToolTipComponent
-                                                icon="IconBuildingCommunity"
+                                                :icon="IconBuildingCommunity"
                                                 icon-size="w-4 h-4"
                                                 tooltip-text="ServiceProvider"
                                                 direction="top"
@@ -91,7 +91,7 @@
                                                 use-translation
                                             />
                                             <ToolTipComponent
-                                                icon="IconAlertTriangle"
+                                                :icon="IconAlertTriangle"
                                                 icon-size="w-4 h-4"
                                                 :tooltip-text="$t('User already assigned as {0}', [user.qualification])"
                                                 direction="top"
@@ -100,7 +100,7 @@
                                             />
                                             <ToolTipComponent
                                                 v-if="user.hasCollision"
-                                                icon="IconClock"
+                                                :icon="IconClock"
                                                 icon-size="w-4 h-4"
                                                 :tooltip-text="getCollisionTooltip(user)"
                                                 direction="top"
@@ -144,6 +144,7 @@ import axios from "axios";
 import SingleEntityInShift from "@/Pages/Shifts/DailyViewComponents/SingleEntityInShift.vue";
 import {can, is} from "laravel-permission-to-vuejs";
 import {useI18n} from "vue-i18n";
+import {IconAlertTriangle, IconBuildingCommunity, IconClock, IconId} from "@tabler/icons-vue";
 
 const props = defineProps({
     shift: Object,

--- a/resources/js/Pages/TimelinePreset/Components/SingleTimelinePreset.vue
+++ b/resources/js/Pages/TimelinePreset/Components/SingleTimelinePreset.vue
@@ -5,7 +5,7 @@
                 {{ timelinePreset.name }}
             </div>
             <div class="flex items-center gap-x-2">
-                <component is="IconWand" class="h-4 w-4 rounded-full text-white hover:text-gray-300 transition-colors duration-300 ease-in-out cursor-pointer hidden" stroke-width="1.5"/>
+                <component :is="IconWand" class="h-4 w-4 rounded-full text-white hover:text-gray-300 transition-colors duration-300 ease-in-out cursor-pointer hidden" stroke-width="1.5"/>
                 <BaseMenu white-icon dots-size="h-4 w-4" has-no-offset>
                     <BaseMenuItem title="Edit" :icon="IconEdit" @click="showEditTimelinePresetModal = true" />
                     <BaseMenuItem title="Duplicate" :icon="IconCopy" @click="copyTimelinePreset" />
@@ -43,7 +43,7 @@ import {ref} from "vue";
 import SingleTimesInPreset from "@/Pages/TimelinePreset/Components/SingleTimesInPreset.vue";
 import {router} from "@inertiajs/vue3";
 import ConfirmDeleteModal from "@/Layouts/Components/ConfirmDeleteModal.vue";
-import {IconCopy, IconEdit, IconTrash} from "@tabler/icons-vue";
+import {IconCopy, IconEdit, IconTrash, IconWand} from "@tabler/icons-vue";
 
 const props = defineProps({
     timelinePreset: {

--- a/resources/js/Pages/TimelinePreset/Components/SingleTimelinePreset.vue
+++ b/resources/js/Pages/TimelinePreset/Components/SingleTimelinePreset.vue
@@ -7,9 +7,9 @@
             <div class="flex items-center gap-x-2">
                 <component is="IconWand" class="h-4 w-4 rounded-full text-white hover:text-gray-300 transition-colors duration-300 ease-in-out cursor-pointer hidden" stroke-width="1.5"/>
                 <BaseMenu white-icon dots-size="h-4 w-4" has-no-offset>
-                    <BaseMenuItem title="Edit" @click="showEditTimelinePresetModal = true" />
-                    <BaseMenuItem title="Duplicate" icon="IconCopy" @click="copyTimelinePreset" />
-                    <BaseMenuItem title="Delete" icon="IconTrash" @click="showConfirmDeleteModal = true" />
+                    <BaseMenuItem title="Edit" :icon="IconEdit" @click="showEditTimelinePresetModal = true" />
+                    <BaseMenuItem title="Duplicate" :icon="IconCopy" @click="copyTimelinePreset" />
+                    <BaseMenuItem title="Delete" :icon="IconTrash" @click="showConfirmDeleteModal = true" />
                 </BaseMenu>
             </div>
         </div>
@@ -43,6 +43,7 @@ import {ref} from "vue";
 import SingleTimesInPreset from "@/Pages/TimelinePreset/Components/SingleTimesInPreset.vue";
 import {router} from "@inertiajs/vue3";
 import ConfirmDeleteModal from "@/Layouts/Components/ConfirmDeleteModal.vue";
+import {IconCopy, IconEdit, IconTrash} from "@tabler/icons-vue";
 
 const props = defineProps({
     timelinePreset: {

--- a/resources/js/Pages/TimelinePreset/Components/SingleTimesInPreset.vue
+++ b/resources/js/Pages/TimelinePreset/Components/SingleTimesInPreset.vue
@@ -6,7 +6,7 @@
             <div v-if="!time.start && time.end">Bis {{ time.end }}</div>
             {{ time.description }}
         </div>
-        <component is="IconTrash" @click="showConfirmDeleteModal = true" stroke-width="1.5" class="invisible min-h-5 min-w-5 h-5 w-5 hover:text-red-600 group-hover:visible transition-colors duration-300 ease-in-out cursor-pointer"/>
+        <component :is="IconTrash" @click="showConfirmDeleteModal = true" stroke-width="1.5" class="invisible min-h-5 min-w-5 h-5 w-5 hover:text-red-600 group-hover:visible transition-colors duration-300 ease-in-out cursor-pointer"/>
     </div>
 
     <ConfirmDeleteModal
@@ -23,6 +23,7 @@
 import ConfirmDeleteModal from "@/Layouts/Components/ConfirmDeleteModal.vue";
 import {ref} from "vue";
 import {router} from "@inertiajs/vue3";
+import {IconTrash} from "@tabler/icons-vue";
 
 const props = defineProps({
     time: {


### PR DESCRIPTION
This pull request standardizes how icon components are used throughout the codebase by switching from the legacy `is="IconName"` syntax to the more explicit `:is="IconName"` binding. Additionally, it ensures that all icon components are properly imported from the `@tabler/icons-vue` package where necessary. These changes improve code clarity, maintainability, and prevent potential runtime issues due to missing imports or incorrect bindings.

**Icon usage standardization:**

* Replaced all instances of `<component is="IconName" />` with `<component :is="IconName" />` in files such as `ArtworkSingleContact.vue`, `NotificationToast.vue`, `BaseInput.vue`, `MultiAlertComponent.vue`, `FullEventInCalendar.vue`, `AddNewChat.vue`, `SingleChatInOverview.vue`, and `PopupChat.vue`. [[1]](diffhunk://#diff-1f0f4a83c436d2815cc4f1684bcd1a909948b37462a756f1db57432cdbd46581L11-R12) [[2]](diffhunk://#diff-d22d7f0f1e2ff6aad544e3ed23bb7dff34c0969fcbf2e472b5b7879f232447a8L29-R29) [[3]](diffhunk://#diff-23b5dd704cd4cfc28f458ef68f2d3936ffe2301d94fe22ee00d796e8e38a4c10L32-R32) [[4]](diffhunk://#diff-23b5dd704cd4cfc28f458ef68f2d3936ffe2301d94fe22ee00d796e8e38a4c10L42-R42) [[5]](diffhunk://#diff-1a511393148a437997038a2c2f56dab5c407ac06044f00226e9c5599a202d1fcL13-R13) [[6]](diffhunk://#diff-e0359ef450e74b90dc6719d747a962d1cdb6d5ea8042521b2734851b2fcb155bL10-R10) [[7]](diffhunk://#diff-641ab316c4be4bf3d9d869f8fa474a6f97fa7e62a5a47c19b5210de64a4821abL41-R41) [[8]](diffhunk://#diff-1acf174806ce2b3afe1fef75bbf43417bdb14423245accc964a59653533868c2L12-R12) [[9]](diffhunk://#diff-07ff66e940e71936443332757f54cad246b8ed02ca56e40f7071f6f42382eb4eL21-R21) [[10]](diffhunk://#diff-07ff66e940e71936443332757f54cad246b8ed02ca56e40f7071f6f42382eb4eL56-R64) [[11]](diffhunk://#diff-07ff66e940e71936443332757f54cad246b8ed02ca56e40f7071f6f42382eb4eL74-R74) [[12]](diffhunk://#diff-07ff66e940e71936443332757f54cad246b8ed02ca56e40f7071f6f42382eb4eL103-R108) [[13]](diffhunk://#diff-07ff66e940e71936443332757f54cad246b8ed02ca56e40f7071f6f42382eb4eL143-R143) [[14]](diffhunk://#diff-07ff66e940e71936443332757f54cad246b8ed02ca56e40f7071f6f42382eb4eL170-R170)

**Icon import consistency:**

* Added missing imports for used icons from `@tabler/icons-vue` in relevant files, ensuring all icons referenced via `:is="IconName"` are properly available in the component scope. [[1]](diffhunk://#diff-1f0f4a83c436d2815cc4f1684bcd1a909948b37462a756f1db57432cdbd46581R65) [[2]](diffhunk://#diff-d22d7f0f1e2ff6aad544e3ed23bb7dff34c0969fcbf2e472b5b7879f232447a8R42) [[3]](diffhunk://#diff-23b5dd704cd4cfc28f458ef68f2d3936ffe2301d94fe22ee00d796e8e38a4c10R67) [[4]](diffhunk://#diff-1a511393148a437997038a2c2f56dab5c407ac06044f00226e9c5599a202d1fcR32-R33) [[5]](diffhunk://#diff-e0359ef450e74b90dc6719d747a962d1cdb6d5ea8042521b2734851b2fcb155bL599-R602) [[6]](diffhunk://#diff-641ab316c4be4bf3d9d869f8fa474a6f97fa7e62a5a47c19b5210de64a4821abR82) [[7]](diffhunk://#diff-1acf174806ce2b3afe1fef75bbf43417bdb14423245accc964a59653533868c2R46)

**Prop usage for icon components:**

* Updated usages of icon props in `ToolTipComponent` to use `:icon="IconName"` instead of `icon="IconName"` for consistency and proper binding. [[1]](diffhunk://#diff-42f38f514b27a2d3604dd74fd8e4e6a180b1ceaa381f1e7734a0a1e173d06a82L8-R16) [[2]](diffhunk://#diff-07ff66e940e71936443332757f54cad246b8ed02ca56e40f7071f6f42382eb4eL45-R45) [[3]](diffhunk://#diff-07ff66e940e71936443332757f54cad246b8ed02ca56e40f7071f6f42382eb4eL56-R64) [[4]](diffhunk://#diff-07ff66e940e71936443332757f54cad246b8ed02ca56e40f7071f6f42382eb4eL83-R83) [[5]](diffhunk://#diff-07ff66e940e71936443332757f54cad246b8ed02ca56e40f7071f6f42382eb4eL119-R119) [[6]](diffhunk://#diff-07ff66e940e71936443332757f54cad246b8ed02ca56e40f7071f6f42382eb4eL129-R129)

These changes collectively enhance the reliability and readability of icon usage across the application's Vue components.